### PR TITLE
Fix conda build workflow

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install conda-build
         shell: bash -l {0}
         run: |
-          conda install -y conda-build anaconda-client
+          conda install -y -c conda-forge conda-build anaconda-client
           conda info
 
       - name: Patch meta.yaml with version, sha256, and build number
@@ -86,7 +86,7 @@ jobs:
       - name: Build conda package
         shell: bash -l {0}
         run: |
-          conda build . --output-folder ./conda-output
+          conda-build . --output-folder ./conda-output --channel conda-forge --channel defaults
 
       - name: Find built package
         shell: bash -l {0}

--- a/meta.yaml
+++ b/meta.yaml
@@ -44,7 +44,6 @@ requirements:
     - hdf5plugin <=4.4.0
     - scipy ==1.11.4
     - matplotlib-base ==3.9.2
-    - opencv-contrib-python-headless==4.11.0.86
     - py-opencv >=4.10.0
     - pyside6 ==6.7.2
     - pyfai <=2024.1.0


### PR DESCRIPTION
Update the conda build workflow to use the conda-forge channel for package installation and building, ensuring compatibility and access to the latest packages.