### PR TITLE
Add expanded Quadrant Folding batch scope processing

### DIFF
--- a/musclex/CalibrationSettings/CalibrationSettings.py
+++ b/musclex/CalibrationSettings/CalibrationSettings.py
@@ -27,6 +27,7 @@ authorization from Illinois Institute of Technology.
 """
 
 from os.path import exists
+import copy
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
 import fabio
@@ -147,6 +148,7 @@ class CalibrationSettings(QDialog):
         self.pathText.setEnabled(False)
         self.browseButton = QPushButton("Browse")
         self.unsetButton = QPushButton("Unset")
+        self.loadButton = QPushButton("Load Calibration File")
         self.calImgFigure = plt.figure()
         self.calImgCanvas = FigureCanvas(self.calImgFigure)
         self.calImgCanvas.setHidden(True)
@@ -334,6 +336,7 @@ class CalibrationSettings(QDialog):
         self.mainLayout.addWidget(self.manDetector)
         self.mainLayout.addWidget(self.detectorChoice)
         self.mainLayout.addWidget(self.misSettingChkBx)
+        self.mainLayout.addWidget(self.loadButton)
         self.mainLayout.addWidget(self.buttons)
         self.mainLayout.setAlignment(Qt.AlignCenter)
         self.mainLayout.setAlignment(self.buttons, Qt.AlignCenter)
@@ -349,6 +352,7 @@ class CalibrationSettings(QDialog):
         """
         self.browseButton.clicked.connect(self.browseClicked)
         self.unsetButton.clicked.connect(self.unsetCalImg)
+        self.loadButton.clicked.connect(self.loadSavedCalibration)
         self.paramGrpChkBx.clicked.connect(self.paramChecked)
         # self.paramGrp.clicked.connect(self.paramChecked)
         self.calImageGrpChkBox.clicked.connect(self.calImageChecked)
@@ -608,6 +612,113 @@ class CalibrationSettings(QDialog):
     def loadSettings(self):
         """Load cached calibration from the settings directory."""
         return self._settings_manager.load_calibration_cache()
+
+    def loadSavedCalibration(self):
+        """
+        Load saved calibration settings from a user-selected file.
+
+        This restores the last accepted calibration into the dialog without
+        recalculating from points, so users can reuse a point calibration after
+        it has been saved with OK.
+        """
+        cache_path = getAFile(
+            filtr="MuscleX calibration cache (*.info);;All files (*)",
+            path=self.dir_path,
+            parent=self,
+        )
+        if not cache_path:
+            return False
+
+        try:
+            cache = self._settings_manager.load_calibration_cache_file(
+                cache_path, require_settings=True
+            )
+        except Exception as exc:
+            QMessageBox.warning(
+                self,
+                "Load Calibration",
+                f"Could not load the selected calibration file:\n{exc}",
+            )
+            return False
+
+        if cache is None:
+            QMessageBox.warning(
+                self,
+                "Load Calibration",
+                "The selected calibration file was not found.",
+            )
+            return False
+
+        settings = copy.deepcopy(cache["settings"])
+        cal_type = settings.get("type")
+        cal_path = cache.get("path", "")
+
+        self.calSettings = settings
+        self.calFile = str(cal_path)
+        self.pathText.setText(self.calFile if exists(self.calFile) else "")
+        self.cal_img = None
+        self.disp_img = None
+        self.refined_points = None
+        self._last_user_points = None
+
+        if cal_type == "img":
+            self.calImageGrpChkBox.setChecked(True)
+            self.calImageGrp.setEnabled(True)
+            self.paramGrpChkBx.setChecked(False)
+            self.paramGrp.setEnabled(False)
+            if "silverB" in settings:
+                self.silverBehenate.setValue(settings["silverB"])
+            self.manualCal.setEnabled(exists(self.calFile))
+        elif cal_type == "cont":
+            self.paramGrpChkBx.setChecked(True)
+            self.paramGrp.setEnabled(True)
+            self.calImageGrpChkBox.setChecked(False)
+            self.calImageGrp.setEnabled(False)
+            self.lambdaSpnBx.setValue(settings.get("lambda", self.lambdaSpnBx.value()))
+            self.sddSpnBx.setValue(settings.get("sdd", self.sddSpnBx.value()))
+            self.pixsSpnBx.setValue(settings.get("pixel_size", self.pixsSpnBx.value()))
+            self.manualCal.setEnabled(False)
+        else:
+            QMessageBox.warning(
+                self,
+                "Load Calibration",
+                "Saved calibration settings are missing a valid calibration type.",
+            )
+            return False
+
+        if "center" in settings and not self.quadrant_folded:
+            self.centerX.setValue(settings["center"][0])
+            self.centerY.setValue(settings["center"][1])
+
+        detector = settings.get("detector")
+        if detector in self.alldetectorChoices:
+            self.detectorChoice.setCurrentIndex(self.alldetectorChoices.index(detector))
+            self.manDetector.setChecked(True)
+            self.detectorChoice.setEnabled(True)
+        else:
+            self.manDetector.setChecked(False)
+            self.detectorChoice.setEnabled(False)
+
+        if cal_type == "img" and not exists(self.calFile):
+            QMessageBox.warning(
+                self,
+                "Load Calibration",
+                "Saved calibration values were loaded, but the calibration image file was not found.",
+            )
+            self.calImgCanvas.setHidden(True)
+            self.minIntLabel.setHidden(True)
+            self.minInt.setHidden(True)
+            self.maxIntLabel.setHidden(True)
+            self.maxInt.setHidden(True)
+            return True
+
+        self.updateImage()
+        QMessageBox.information(
+            self,
+            "Load Calibration",
+            "Saved calibration settings were loaded.",
+        )
+        return True
 
     def keyPressEvent(self, event):
         """

--- a/musclex/headless/mp_executor.py
+++ b/musclex/headless/mp_executor.py
@@ -153,6 +153,7 @@ def process_one_qf_image(args):
     try:
         dir_path = args["dir_path"]
         filename = args["filename"]
+        save_name = args.get("save_name", os.path.basename(filename))
         spec = args["spec"]
         flags = args["flags"]
         bgsub = args.get("bgsub", "None")
@@ -189,12 +190,14 @@ def process_one_qf_image(args):
         if img is None:
             raise RuntimeError(f"load_image_via_spec returned None for {filename}")
 
-        settings_manager = SettingsManager(dir_path)
+        # settings_manager = SettingsManager(dir_path)
+        settings_manager = SettingsManager(output_dir)
 
         image_data = ImageData(
             img=img,
-            img_path=dir_path,
-            img_name=filename,
+            img_path=output_dir,
+            # img_name=filename,
+            img_name=save_name,
             center=tuple(manual_center) if manual_center is not None else None,
             rotation=manual_rotation,
             apply_blank=apply_blank,
@@ -224,7 +227,8 @@ def process_one_qf_image(args):
         # ---- Write the background tif and compute bg_sum ----
         bg_sum = None
         try:
-            bg_sum = _save_qf_background(quadFold, dir_path)
+            # bg_sum = _save_qf_background(quadFold, dir_path)
+            bg_sum = _save_qf_background(quadFold, output_dir)
         except Exception as e:
             print(f"[QF worker {pid}] Failed to save background for {filename}: {e}")
 
@@ -249,6 +253,8 @@ def process_one_qf_image(args):
             "rotation": rotation,
             "bg_sum": bg_sum,
             "error": None,
+            "output_dir": output_dir,
+            "save_name": save_name,
         }
 
     except Exception:

--- a/musclex/ui/QFAlignmentDialog.py
+++ b/musclex/ui/QFAlignmentDialog.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 import logging
+import os
 
 from PySide6.QtCore import Qt, QTimer, Signal
 from PySide6.QtWidgets import (
@@ -33,9 +34,10 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
 )
 
-from musclex.ui.add_intensities_row_mapper import SingleRowMapper
+from musclex.ui.add_intensities_row_mapper import SourceFolderRowMapper
 from musclex.ui.widgets.image_alignment_table import ColKey
 from musclex.ui.widgets.image_alignment_widget import ImageAlignmentWidget
+from musclex.utils.settings_manager import SettingsManager
 
 logger = logging.getLogger(__name__)
 
@@ -67,16 +69,10 @@ class QFAlignmentDialog(QDialog):
         self.setWindowFlags(self.windowFlags() | Qt.WindowMinMaxButtonsHint)
 
         self.workspace = workspace
+        self._settings_manager_cache = {}
+        self._load_selected_batch_sources_if_needed()
         # row == file_manager index (QF does not group images)
-        self._row_mapper = SingleRowMapper(
-            lambda: (
-                list(self.workspace.navigator.file_manager.names)
-                if self.workspace
-                and self.workspace.navigator
-                and self.workspace.navigator.file_manager
-                else []
-            )
-        )
+        self._row_mapper = SourceFolderRowMapper(self.workspace)
 
         self._build_ui()
         self._connect_signals()
@@ -92,23 +88,25 @@ class QFAlignmentDialog(QDialog):
         # FOLD_STD is appended at the end so the symmetry score is read alongside
         # the existing image-diff metric.
         col_map = {
-            ColKey.FRAME: 0,
-            ColKey.CENTER: 1,
-            ColKey.CENTER_MODE: 2,
-            ColKey.CENTER_DIST: 3,
-            ColKey.AUTO_CENTER: 4,
-            ColKey.AUTO_MANUAL_DIST: 5,
-            ColKey.ROTATION: 6,
-            ColKey.ROTATION_MODE: 7,
-            ColKey.ROTATION_DIFF: 8,
-            ColKey.AUTO_ROTATION: 9,
-            ColKey.AUTO_ROT_DIFF: 10,
-            ColKey.SIZE: 11,
-            ColKey.IMAGE_DIFF: 12,
-            ColKey.FOLD_STD: 13,
-            ColKey.FOLD_STD_NORM: 14,
+            ColKey.FOLDER: 0,
+            ColKey.FRAME: 1,
+            ColKey.CENTER: 2,
+            ColKey.CENTER_MODE: 3,
+            ColKey.CENTER_DIST: 4,
+            ColKey.AUTO_CENTER: 5,
+            ColKey.AUTO_MANUAL_DIST: 6,
+            ColKey.ROTATION: 7,
+            ColKey.ROTATION_MODE: 8,
+            ColKey.ROTATION_DIFF: 9,
+            ColKey.AUTO_ROTATION: 10,
+            ColKey.AUTO_ROT_DIFF: 11,
+            ColKey.SIZE: 12,
+            ColKey.IMAGE_DIFF: 13,
+            ColKey.FOLD_STD: 14,
+            ColKey.FOLD_STD_NORM: 15,
         }
         headers = [
+            "Folder",
             "Frame",
             "Original\nCenter",
             "Center\nMode",
@@ -137,6 +135,7 @@ class QFAlignmentDialog(QDialog):
             worker_dir_path=worker_dir,
             enable_symmetry_test=True,
             detection_button_position="bottom_after_thresholds",
+            settings_resolver=self._settings_for_alignment_row,
             parent=self,
         )
         # Use the default context menu (Set Center/Rotation, Set Global Base, Ignore).
@@ -144,7 +143,8 @@ class QFAlignmentDialog(QDialog):
 
         # Allow the Frame column to be resized interactively.
         header = self.panel.table.horizontalHeader()
-        header.setSectionResizeMode(0, QHeaderView.Interactive)
+        header.setSectionResizeMode(col_map[ColKey.FOLDER], QHeaderView.Interactive)
+        header.setSectionResizeMode(col_map[ColKey.FRAME], QHeaderView.Interactive)
 
         # Brief usage hint at the top of the dialog.
         hint = QLabel(
@@ -212,6 +212,7 @@ class QFAlignmentDialog(QDialog):
 
     def _initialize_panel(self):
         """Populate the table from the current workspace state and select the active row."""
+        self._load_selected_batch_sources_if_needed()
         fm = self.workspace.navigator.file_manager
         if fm is None or not fm.names:
             logger.info("QFAlignmentDialog: file_manager is empty, skipping table init")
@@ -285,6 +286,53 @@ class QFAlignmentDialog(QDialog):
         time to settle before ``init_table`` is called.
         """
         QTimer.singleShot(0, self._initialize_panel)
+
+    def _load_selected_batch_sources_if_needed(self):
+        """Use the same flattened FileManager view that QF batch processing uses."""
+        parent = self.parent()
+        folders = list(getattr(parent, "selected_batch_folders", []) or [])
+        if not folders:
+            return
+
+        fm = self.workspace.navigator.file_manager
+        if fm is None:
+            return
+
+        try:
+            fm.load_from_sources(folders)
+            self._settings_manager_cache.clear()
+        except Exception as exc:
+            logger.warning("Failed to load QF batch folders for alignment: %s", exc)
+
+    def _settings_for_alignment_row(self, row, name):
+        """Return the source folder SettingsManager and basename key for a row."""
+        fm = self.workspace.navigator.file_manager
+        if fm is None:
+            return self.workspace.settings_manager, name
+
+        fm_idx = self._row_mapper.fm_index_for_row(row)
+        if fm_idx is None or fm_idx >= len(fm.specs):
+            return self.workspace.settings_manager, name
+
+        spec = fm.specs[fm_idx]
+        source_dir = None
+        key = os.path.basename(str(name))
+
+        if isinstance(spec, tuple) and len(spec) >= 3 and spec[0] == "h5":
+            source_dir = os.path.dirname(str(spec[1]))
+        elif isinstance(spec, tuple) and len(spec) >= 2:
+            source_path = str(spec[1])
+            source_dir = os.path.dirname(source_path)
+            key = os.path.basename(source_path)
+
+        if not source_dir:
+            return self.workspace.settings_manager, name
+
+        manager = self._settings_manager_cache.get(source_dir)
+        if manager is None:
+            manager = SettingsManager(source_dir)
+            self._settings_manager_cache[source_dir] = manager
+        return manager, key
 
     def _on_request_set_center_rotation(self, row: int):
         """

--- a/musclex/ui/QuadrantFoldingGUI.py
+++ b/musclex/ui/QuadrantFoldingGUI.py
@@ -55,6 +55,7 @@ from ..utils.file_manager import *
 from ..utils.image_processor import *
 from ..utils import ImageData
 from ..utils import qf_defaults
+from ..utils.settings_manager import SettingsManager
 
 from ..modules.QuadrantFolder import QuadrantFolder
 from ..csv_manager.QF_CSVManager import QF_CSVManager
@@ -91,7 +92,7 @@ from .widgets.collapsible_groupbox import CollapsibleGroupBox
 from .widgets.center_settings_widget import CenterSettingsWidget
 from .widgets.rotation_settings_widget import RotationSettingsWidget
 from .widgets.blank_mask_settings_widget import BlankMaskSettingsWidget
-from .widgets import ProcessingWorkspace
+from .widgets import ProcessingWorkspace, BatchFolderSelectionDialog
 from .base_gui import BaseGUI
 from ..utils.background_search import (
     makeFullImage,
@@ -495,6 +496,7 @@ class QuadrantFoldingGUI(BaseGUI):
         # self.mask_max = None
         # TODO: review whether these BG-related variables are still needed
         self.bgAsyncDict = {}
+        self.selected_batch_folders = []
         self.batchCsvManagers = {}
 
     # ===== BaseGUI abstract methods implementation =====
@@ -530,7 +532,7 @@ class QuadrantFoldingGUI(BaseGUI):
         self.image_viewer = self.workspace.navigator.image_viewer
         self.file_manager = self.workspace.file_manager
         self.navControls = self.workspace.navigator.nav_controls
-        self.navControls.set_batch_scope_visible(True)
+        self.navControls.set_select_batch_folder_visible(True)
         self.right_panel = self.workspace.right_panel
 
         # Expose select buttons from navigator
@@ -2211,6 +2213,9 @@ class QuadrantFoldingGUI(BaseGUI):
         self.navControls.processH5Button.toggled.connect(self.h5batchProcBtnToggled)
         self.processFolderWithSelections.clicked.connect(
             self.navControls.processFolderButton.click
+        )
+        self.navControls.select_batch_folder_button.clicked.connect(
+            self.choose_batch_folder_for_processing
         )
 
         # NOTE: Filename editing is handled internally by ImageNavigatorWidget._on_filename_changed()
@@ -4805,6 +4810,35 @@ class QuadrantFoldingGUI(BaseGUI):
             except Exception:
                 manual_center, manual_rotation = (None, None)
 
+        if self.selected_batch_folders and self.workspace is not None:
+            try:
+                batch_center, batch_rotation = self.workspace.get_batch_all_geometry()
+            except Exception:
+                batch_center, batch_rotation = (None, None)
+
+            if batch_center is not None:
+                manual_center = batch_center
+            if batch_rotation is not None:
+                manual_rotation = batch_rotation
+
+            if batch_center is not None or batch_rotation is not None:
+                try:
+                    folder_settings = SettingsManager(source_dir)
+                    if batch_center is not None:
+                        folder_settings.set_center(
+                            save_name, batch_center, "propagated_batch_folder"
+                        )
+                        folder_settings.save_center()
+                    if batch_rotation is not None:
+                        folder_settings.set_rotation(
+                            save_name, batch_rotation, "propagated_batch_folder"
+                        )
+                        folder_settings.save_rotation()
+                except Exception as e:
+                    print(
+                        f"Warning: failed to save batch geometry for {save_name}: {e}"
+                    )
+
         blank_mask_config = {
             "apply_blank": False,
             "apply_mask": False,
@@ -6158,52 +6192,15 @@ class QuadrantFoldingGUI(BaseGUI):
         """
         Triggered when a folder has been selected to process it
         """
-        if (
-            self.navControls.process_sibling_folders_enabled()
-            or self.navControls.process_recursively_enabled()
-        ):
-            sources = self._collect_batch_sources()
-            if not sources:
-                QMessageBox.warning(self, "Process Folder", "No image folders found.")
-                self.navControls.processFolderButton.setChecked(False)
-                return
+        if self.selected_batch_folders:
+            sources = self.selected_batch_folders
             self.file_manager.load_from_sources(sources)
             idxs = range(len(self.file_manager.names))
-            self._process_image_list(idxs, text="Process Selected Folder Scope")
+            self._process_image_list(idxs, text="Process Selected Folders")
             return
 
         idxs = range(len(self.file_manager.names))
         self._process_image_list(idxs, text="Process Current Folder")
-
-    def _iter_candidate_dirs(self, root, recursive):
-        if not recursive:
-            if not is_exclude_scan_dir(root):
-                yield Path(root)
-            return
-
-        for parent, dirnames, _filenames in os.walk(root):
-            dirnames[:] = [
-                d for d in dirnames if not is_exclude_scan_dir(os.path.join(parent, d))
-            ]
-
-            if not is_exclude_scan_dir(parent):
-                yield Path(parent)
-
-    def _collect_batch_sources(self):
-        current_dir = Path(self.file_manager.dir_path).resolve()
-        recursive = self.navControls.process_recursively_enabled()
-        siblings = self.navControls.process_sibling_folders_enabled()
-
-        roots = [current_dir]
-        if siblings and current_dir.parent.exists():
-            roots = [p for p in current_dir.parent.iterdir() if p.is_dir()]
-
-        sources = []
-        for root in roots:
-            for folder in self._iter_candidate_dirs(root, recursive):
-                if self._folder_has_possible_images(folder):
-                    sources.append(folder)
-        return sorted(set(sources))
 
     def _folder_has_possible_images(self, folder):
         try:
@@ -6417,8 +6414,6 @@ class QuadrantFoldingGUI(BaseGUI):
         ret = errMsg.exec_()
 
         if ret == QMessageBox.Yes:
-            self.automatic_save_settings()
-
             # Reset progress bar for batch processing (percentage mode)
             self.progressBar.setRange(0, 100)
             self.progressBar.setFormat("%p%")
@@ -6856,6 +6851,8 @@ class QuadrantFoldingGUI(BaseGUI):
             dir_path: Directory path of the loaded file/folder
         """
         QApplication.setOverrideCursor(Qt.WaitCursor)
+        self.selected_batch_folders = []
+        self.navControls.select_batch_folder_button.setText("Select Batch Folders")
 
         try:
             # Update file path
@@ -7070,6 +7067,40 @@ class QuadrantFoldingGUI(BaseGUI):
 
     # NOTE: fileNameChanged() removed - handled by ImageNavigatorWidget._on_filename_changed()
     # The widget automatically emits imageChanged signal which triggers _on_image_changed()
+    def choose_batch_folder_for_processing(self):
+        dialog = BatchFolderSelectionDialog(
+            parent=self,
+            start_dir=self.file_manager.dir_path if self.file_manager else None,
+        )
+        if dialog.exec() != QDialog.Accepted:
+            return
+
+        selected_folders = dialog.selected_folders()
+        valid = [
+            folder
+            for folder in selected_folders
+            if self._folder_has_possible_images(folder)
+        ]
+
+        skipped = len(selected_folders) - len(valid)
+        self.selected_batch_folders = valid
+
+        count = len(self.selected_batch_folders)
+
+        if count:
+            self.navControls.select_batch_folder_button.setText(
+                f"Selected {count} folder(s)"
+            )
+            self.navControls.processFolderButton.setText(f"Process Batch Folder(s)")
+        else:
+            self.navControls.select_batch_folder_button.setText("Select Batch Folders")
+
+        if skipped:
+            QMessageBox.information(
+                self,
+                "Batch Folder Selection",
+                f"{skipped} folder(s) were skipped because they do not contain any supported image files.",
+            )
 
     def showAbout(self):
         """

--- a/musclex/ui/QuadrantFoldingGUI.py
+++ b/musclex/ui/QuadrantFoldingGUI.py
@@ -6852,7 +6852,8 @@ class QuadrantFoldingGUI(BaseGUI):
         """
         QApplication.setOverrideCursor(Qt.WaitCursor)
         self.selected_batch_folders = []
-        self.navControls.select_batch_folder_button.setText("Select Batch Folders")
+        self.navControls.reset_process_folder_text()
+        self.navControls.reset_batch_folder_button_text()
 
         try:
             # Update file path
@@ -7093,7 +7094,8 @@ class QuadrantFoldingGUI(BaseGUI):
             )
             self.navControls.processFolderButton.setText(f"Process Batch Folder(s)")
         else:
-            self.navControls.select_batch_folder_button.setText("Select Batch Folders")
+            self.navControls.reset_process_folder_text()
+            self.navControls.reset_batch_folder_button_text()
 
         if skipped:
             QMessageBox.information(

--- a/musclex/ui/QuadrantFoldingGUI.py
+++ b/musclex/ui/QuadrantFoldingGUI.py
@@ -6417,6 +6417,8 @@ class QuadrantFoldingGUI(BaseGUI):
         ret = errMsg.exec_()
 
         if ret == QMessageBox.Yes:
+            self.automatic_save_settings()
+
             # Reset progress bar for batch processing (percentage mode)
             self.progressBar.setRange(0, 100)
             self.progressBar.setFormat("%p%")
@@ -6487,10 +6489,9 @@ class QuadrantFoldingGUI(BaseGUI):
             range(start_idx, end_idx + 1), text="Process Current H5 File"
         )
 
-    def saveSettings(self):
-        """
-        save settings to json
-        """
+    def _collect_settings(self):
+        """Collect current settings from the UI widgets and return as a dictionary."""
+
         # Start from all current UI flags
         settings = dict(self.getFlags())
 
@@ -6555,13 +6556,28 @@ class QuadrantFoldingGUI(BaseGUI):
 
         if self.quadFold is not None and "bgsub" in self.quadFold.info:
             settings["bgsub"] = self.quadFold.info["bgsub"]
+        return settings
 
+    def saveSettings(self):
+        """
+        save settings to json
+        """
+        settings = self._collect_settings()
         filename = getSaveFile(
             os.path.join("musclex", "settings", "qfsettings.json"), None
         )
         if filename != "":
             with open(filename, "w") as f:
                 json.dump(settings, f)
+
+    def automatic_save_settings(self):
+        settings = self._collect_settings()
+        auto_save_dir = self.workspace.settings_manager.settings_path
+        auto_save_dir.mkdir(parents=True, exist_ok=True)
+
+        filename = auto_save_dir / "qfsettings.json"
+        with open(filename, "w") as f:
+            json.dump(settings, f, indent=2)
 
     def loadSettings(self):
         """

--- a/musclex/ui/QuadrantFoldingGUI.py
+++ b/musclex/ui/QuadrantFoldingGUI.py
@@ -495,6 +495,7 @@ class QuadrantFoldingGUI(BaseGUI):
         # self.mask_max = None
         # TODO: review whether these BG-related variables are still needed
         self.bgAsyncDict = {}
+        self.batchCsvManagers = {}
 
     # ===== BaseGUI abstract methods implementation =====
 
@@ -529,6 +530,7 @@ class QuadrantFoldingGUI(BaseGUI):
         self.image_viewer = self.workspace.navigator.image_viewer
         self.file_manager = self.workspace.file_manager
         self.navControls = self.workspace.navigator.nav_controls
+        self.navControls.set_batch_scope_visible(True)
         self.right_panel = self.workspace.right_panel
 
         # Expose select buttons from navigator
@@ -1004,9 +1006,7 @@ class QuadrantFoldingGUI(BaseGUI):
         subtraction_main_layout.addWidget(self.openBGSettingsButton, 1, 2, 1, 2)
         subtraction_main_layout.addWidget(self.manualSettingsContainer, 2, 0, 1, 4)
         subtraction_main_layout.addWidget(self.manualSettingsOutContainer, 3, 0, 1, 4)
-        subtraction_main_layout.addWidget(
-            self.transitionSettingsContainer, 4, 0, 1, 4
-        )
+        subtraction_main_layout.addWidget(self.transitionSettingsContainer, 4, 0, 1, 4)
         subtraction_main_layout.addWidget(self.applyBGButtonProxy, 5, 0, 1, 4)
         self.subtractionGroupMain.setLayout(subtraction_main_layout)
 
@@ -4771,6 +4771,24 @@ class QuadrantFoldingGUI(BaseGUI):
         filename = self.file_manager.names[job_index]
         spec = self.file_manager.specs[job_index]
 
+        if isinstance(spec, tuple) and len(spec) >= 3 and spec[0] == "h5":
+            source_dir = os.path.dirname(spec[1])
+            save_name = os.path.basename(filename)
+        else:
+            source_file = (
+                spec[1] if isinstance(spec, tuple) and len(spec) >= 2 else None
+            )
+            source_dir = (
+                os.path.dirname(str(source_file))
+                if source_file
+                else self.file_manager.dir_path
+            )
+            save_name = (
+                os.path.basename(str(source_file))
+                if source_file
+                else os.path.basename(filename)
+            )
+
         # Snapshot flags. Use deepcopy so any subsequent UI edits while the
         # batch is running don't sneak into already-submitted jobs.
         flags = copy.deepcopy(
@@ -4805,11 +4823,11 @@ class QuadrantFoldingGUI(BaseGUI):
         if self.calSettings is not None and "detector" in self.calSettings:
             detector = self.calSettings["detector"]
 
-        out = (
-            self.workspace.dir_context.output_dir
-            if self.workspace and self.workspace.dir_context
-            else self.file_manager.dir_path
-        )
+        # out = (
+        #     self.workspace.dir_context.output_dir
+        #     if self.workspace and self.workspace.dir_context
+        #     else self.file_manager.dir_path
+        # )
 
         compress_folded = True
         if hasattr(self, "compressFoldedImageChkBx"):
@@ -4821,12 +4839,14 @@ class QuadrantFoldingGUI(BaseGUI):
         return {
             "dir_path": self.file_manager.dir_path,
             "filename": filename,
+            "save_name": save_name,
             "spec": spec,
             "flags": flags,
             "bgsub": (
                 self.bgChoiceIn.currentText() if hasattr(self, "bgChoiceIn") else "None"
             ),
-            "output_dir": out,
+            # "output_dir": out,
+            "output_dir": source_dir,
             "manual_center": (
                 tuple(manual_center) if manual_center is not None else None
             ),
@@ -4963,12 +4983,14 @@ class QuadrantFoldingGUI(BaseGUI):
         processing_flags = (
             result.get("processing_flags") if isinstance(result, dict) else None
         )
-
-        out = (
-            self.workspace.dir_context.output_dir
-            if self.workspace and self.workspace.dir_context
-            else self.filePath
-        )
+        if result.get("output_dir", None):
+            out = result["output_dir"]
+        else:
+            out = (
+                self.workspace.dir_context.output_dir
+                if self.workspace and self.workspace.dir_context
+                else self.filePath
+            )
 
         try:
             os.makedirs(join(out, "qf_results"), exist_ok=True)
@@ -4980,8 +5002,11 @@ class QuadrantFoldingGUI(BaseGUI):
         # CSV write needs a quadFold-like object. Build a lightweight
         # shim mirroring the fields csvManager.writeNewData() reads.
         try:
-            if info is not None and self.csvManager is not None:
-                self.csvManager.writeNewData(
+            csv_manager = self._get_batch_csv_manager(out)
+            # if info is not None and self.csvManager is not None:
+            if info is not None and csv_manager is not None:
+                # self.csvManager.writeNewData(
+                csv_manager.writeNewData(
                     _BatchQuadFoldProxy(
                         filename, info, center, rotation, has_result, processing_flags
                     )
@@ -4994,13 +5019,15 @@ class QuadrantFoldingGUI(BaseGUI):
                 self._upsert_background_metrics_csv(
                     quad_fold=_BatchQuadFoldProxy(
                         filename, info, center, rotation, has_result
-                    )
+                    ),
+                    output_dir=out,
                 )
         except Exception as e:
             print(f"Failed to upsert background metrics for {filename}: {e}")
 
         if bg_sum is not None:
-            self.bgAsyncDict[filename] = bg_sum
+            # self.bgAsyncDict[filename] = bg_sum
+            self.bgAsyncDict.setdefault(out, {})[filename] = bg_sum
 
         # Drop the snapshot — we no longer need to retry this job.
         self.pendingJobArgs.pop(task.job_index, None)
@@ -5133,26 +5160,40 @@ class QuadrantFoldingGUI(BaseGUI):
             pass
 
         try:
-            if self.csvManager is not None:
+            if self.batchCsvManagers:
+                for manager in self.batchCsvManagers.values():
+                    manager.sortCSV()
+            elif self.csvManager is not None:
                 self.csvManager.sortCSV()
         except Exception as e:
             print(f"Failed to sort summary CSV: {e}")
 
-        out = (
-            self.workspace.dir_context.output_dir
-            if self.workspace.dir_context
-            else self.filePath
-        )
+        # out = (
+        #     self.workspace.dir_context.output_dir
+        #     if self.workspace.dir_context
+        #     else self.filePath
+        # )
         try:
-            os.makedirs(join(out, "qf_results"), exist_ok=True)
-            os.makedirs(join(out, "qf_results", "bg"), exist_ok=True)
-            with open(
-                join(out, "qf_results", "bg", "background_sum.csv"), "w", newline=""
-            ) as csvfile:
-                writer = csv.writer(csvfile)
-                writer.writerow(["Name", "Sum"])
-                for name, total in self.bgAsyncDict.items():
-                    writer.writerow([name, total])
+            # os.makedirs(join(out, "qf_results"), exist_ok=True)
+            # os.makedirs(join(out, "qf_results", "bg"), exist_ok=True)
+            # with open(
+            #     join(out, "qf_results", "bg", "background_sum.csv"), "w", newline=""
+            # ) as csvfile:
+            #     writer = csv.writer(csvfile)
+            #     writer.writerow(["Name", "Sum"])
+            #     for name, total in self.bgAsyncDict.items():
+            #         writer.writerow([name, total])
+            for out, bg_values in self.bgAsyncDict.items():
+                bg_dir = join(out, "qf_results", "bg")
+                os.makedirs(bg_dir, exist_ok=True)
+
+                with open(
+                    join(bg_dir, "background_sum.csv"), "w", newline=""
+                ) as csvfile:
+                    writer = csv.writer(csvfile)
+                    writer.writerow(["Name", "Sum"])
+                    for name, total in bg_values.items():
+                        writer.writerow([name, total])
         except Exception as e:
             print(f"Failed to write aggregated background_sum.csv: {e}")
 
@@ -5167,6 +5208,7 @@ class QuadrantFoldingGUI(BaseGUI):
             pass
 
         self.writeProcessingLog()
+        self.batchCsvManagers.clear()
         # Only show the "Complete" popup on natural completion. For
         # user-initiated Stop we let _updateStopProgress show its own
         # "Stopped" message instead, so the user doesn't get two popups.
@@ -5313,16 +5355,16 @@ class QuadrantFoldingGUI(BaseGUI):
                 print("Setting Rmax to default: 100")
                 qf.info["rmax"] = 100
 
-            csv_mask = (csv_dists >= qf.info["rmin"]) & (
-                csv_dists <= qf.info["rmax"]
-            )
+            csv_mask = (csv_dists >= qf.info["rmin"]) & (csv_dists <= qf.info["rmax"])
 
             csv_total = np.sum(resultImg[csv_mask])
 
             self.csv_bg.loc[filename] = pd.Series({"Sum": total_inten})
             self.csv_bg.to_csv(csv_path)
 
-    def _upsert_background_metrics_csv(self, quad_fold=None, flags=None):
+    def _upsert_background_metrics_csv(
+        self, quad_fold=None, flags=None, output_dir=None
+    ):
         """
         Upsert one row per image into qf_results/bg/background_metrics.csv.
         Row key is image filename (ImageName).
@@ -5443,7 +5485,9 @@ class QuadrantFoldingGUI(BaseGUI):
         ordered_columns = list(row_data.keys())
 
         try:
-            csv_path = join(self.filePath, "qf_results", "bg", "background_metrics.csv")
+            # csv_path = join(self.filePath, "qf_results", "bg", "background_metrics.csv")
+            base_dir = output_dir or self.filePath
+            csv_path = join(base_dir, "qf_results", "bg", "background_metrics.csv")
             os.makedirs(os.path.dirname(csv_path), exist_ok=True)
 
             if exists(csv_path):
@@ -6114,8 +6158,71 @@ class QuadrantFoldingGUI(BaseGUI):
         """
         Triggered when a folder has been selected to process it
         """
+        if (
+            self.navControls.process_sibling_folders_enabled()
+            or self.navControls.process_recursively_enabled()
+        ):
+            sources = self._collect_batch_sources()
+            if not sources:
+                QMessageBox.warning(self, "Process Folder", "No image folders found.")
+                self.navControls.processFolderButton.setChecked(False)
+                return
+            self.file_manager.load_from_sources(sources)
+            idxs = range(len(self.file_manager.names))
+            self._process_image_list(idxs, text="Process Selected Folder Scope")
+            return
+
         idxs = range(len(self.file_manager.names))
         self._process_image_list(idxs, text="Process Current Folder")
+
+    def _iter_candidate_dirs(self, root, recursive):
+        if not recursive:
+            if not is_exclude_scan_dir(root):
+                yield Path(root)
+            return
+
+        for parent, dirnames, _filenames in os.walk(root):
+            dirnames[:] = [
+                d for d in dirnames if not is_exclude_scan_dir(os.path.join(parent, d))
+            ]
+
+            if not is_exclude_scan_dir(parent):
+                yield Path(parent)
+
+    def _collect_batch_sources(self):
+        current_dir = Path(self.file_manager.dir_path).resolve()
+        recursive = self.navControls.process_recursively_enabled()
+        siblings = self.navControls.process_sibling_folders_enabled()
+
+        roots = [current_dir]
+        if siblings and current_dir.parent.exists():
+            roots = [p for p in current_dir.parent.iterdir() if p.is_dir()]
+
+        sources = []
+        for root in roots:
+            for folder in self._iter_candidate_dirs(root, recursive):
+                if self._folder_has_possible_images(folder):
+                    sources.append(folder)
+        return sorted(set(sources))
+
+    def _folder_has_possible_images(self, folder):
+        try:
+            return len(scan_directory_files_sync(str(folder))) > 0
+        except Exception:
+            return False
+
+    def _get_batch_csv_manager(self, output_dir):
+        if not output_dir:
+            return self.csvManager
+
+        if output_dir not in self.batchCsvManagers:
+            self.batchCsvManagers[output_dir] = QF_CSVManager(
+                output_dir,
+                extra_colnames=_qf_setting_keys(),
+                version=__version__,
+            )
+
+        return self.batchCsvManagers[output_dir]
 
     def _process_image_list(self, img_ids, text):
         """

--- a/musclex/ui/QuadrantFoldingGUI.py
+++ b/musclex/ui/QuadrantFoldingGUI.py
@@ -4811,6 +4811,18 @@ class QuadrantFoldingGUI(BaseGUI):
                 manual_center, manual_rotation = (None, None)
 
         if self.selected_batch_folders and self.workspace is not None:
+            folder_settings = None
+            try:
+                folder_settings = SettingsManager(source_dir)
+                source_center = folder_settings.get_center(save_name)
+                source_rotation = folder_settings.get_rotation(save_name)
+                if source_center is not None:
+                    manual_center = source_center
+                if source_rotation is not None:
+                    manual_rotation = source_rotation
+            except Exception as e:
+                print(f"Warning: failed to read batch geometry for {save_name}: {e}")
+
             try:
                 batch_center, batch_rotation = self.workspace.get_batch_all_geometry()
             except Exception:
@@ -4823,7 +4835,8 @@ class QuadrantFoldingGUI(BaseGUI):
 
             if batch_center is not None or batch_rotation is not None:
                 try:
-                    folder_settings = SettingsManager(source_dir)
+                    if folder_settings is None:
+                        folder_settings = SettingsManager(source_dir)
                     if batch_center is not None:
                         folder_settings.set_center(
                             save_name, batch_center, "propagated_batch_folder"
@@ -6193,14 +6206,75 @@ class QuadrantFoldingGUI(BaseGUI):
         Triggered when a folder has been selected to process it
         """
         if self.selected_batch_folders:
-            sources = self.selected_batch_folders
-            self.file_manager.load_from_sources(sources)
+            self._load_selected_batch_folders_into_file_manager(refresh_ui=False)
             idxs = range(len(self.file_manager.names))
             self._process_image_list(idxs, text="Process Selected Folders")
             return
 
+        self._restore_current_folder_after_batch_selection_clear(refresh_ui=False)
         idxs = range(len(self.file_manager.names))
         self._process_image_list(idxs, text="Process Current Folder")
+
+    def _load_selected_batch_folders_into_file_manager(self, refresh_ui=True):
+        """Load selected batch folders into the shared FileManager immediately."""
+        if not self.selected_batch_folders or self.file_manager is None:
+            return
+
+        try:
+            self.file_manager.load_from_sources(self.selected_batch_folders)
+            if refresh_ui:
+                try:
+                    self.workspace.navigator._load_current_image()
+                except Exception:
+                    pass
+        except Exception as e:
+            print(f"Warning: failed to load selected batch folders: {e}")
+
+    def _restore_current_folder_after_batch_selection_clear(self, refresh_ui=True):
+        """Restore the normal folder listing after a cleared batch selection."""
+        fm = self.file_manager
+        if fm is None or not getattr(fm, "source_labels", None):
+            return
+
+        current_dir = getattr(self, "filePath", None)
+        if not current_dir:
+            return
+
+        try:
+            previous_name = getattr(fm, "current_image_name", "") or ""
+            previous_base = os.path.basename(previous_name)
+
+            fm.file_list = scan_directory_files_sync(current_dir)
+            fm._rebuild_path_to_file_idx()
+
+            names, specs, source_index_map, size_map = scan_directory_images_cached(
+                current_dir
+            )
+            fm.dir_path = current_dir
+            fm.names = names
+            fm.specs = specs
+            fm.source_index_map = source_index_map or {}
+            fm.source_labels = []
+            fm.image_sizes = size_map or {}
+
+            if not fm.names:
+                return
+
+            target_idx = 0
+            if previous_base:
+                for idx, name in enumerate(fm.names):
+                    if os.path.basename(name) == previous_base:
+                        target_idx = idx
+                        break
+
+            fm.switch_image_by_index(target_idx)
+            if refresh_ui:
+                try:
+                    self.workspace.navigator._load_current_image()
+                except Exception:
+                    pass
+        except Exception as e:
+            print(f"Warning: failed to restore current folder listing: {e}")
 
     def _folder_has_possible_images(self, folder):
         try:
@@ -7093,9 +7167,11 @@ class QuadrantFoldingGUI(BaseGUI):
                 f"Selected {count} folder(s)"
             )
             self.navControls.processFolderButton.setText(f"Process Batch Folder(s)")
+            self._load_selected_batch_folders_into_file_manager()
         else:
             self.navControls.reset_process_folder_text()
             self.navControls.reset_batch_folder_button_text()
+            self._restore_current_folder_after_batch_selection_clear()
 
         if skipped:
             QMessageBox.information(

--- a/musclex/ui/add_intensities_row_mapper.py
+++ b/musclex/ui/add_intensities_row_mapper.py
@@ -73,6 +73,67 @@ class SingleRowMapper:
             table.setItem(i, table.col(ColKey.FRAME), item)
 
 
+class SourceFolderRowMapper:
+    """Identity mapping that also exposes the FileManager source label.
+
+    Used by QF's alignment dialog when the shared FileManager has been loaded
+    from multiple source folders via ``load_from_sources``.
+    """
+
+    def __init__(self, workspace):
+        self._workspace = workspace
+
+    def _file_manager(self):
+        nav = getattr(self._workspace, "navigator", None)
+        return getattr(nav, "file_manager", None)
+
+    def name_for_row(self, row: int) -> Optional[str]:
+        fm = self._file_manager()
+        if fm is None:
+            return None
+        return fm.names[row] if 0 <= row < len(fm.names) else None
+
+    def fm_index_for_row(self, row: int) -> Optional[int]:
+        fm = self._file_manager()
+        if fm is None or row < 0 or row >= len(fm.names):
+            return None
+        return row
+
+    def row_for_fm_index(self, fm_idx: int) -> Optional[int]:
+        fm = self._file_manager()
+        if fm is None or fm_idx < 0 or fm_idx >= len(fm.names):
+            return None
+        return fm_idx
+
+    def row_count(self) -> int:
+        fm = self._file_manager()
+        return len(fm.names) if fm is not None else 0
+
+    def populate_table(self, table) -> None:
+        """Fill Folder and Frame columns from the shared FileManager."""
+        from musclex.ui.widgets.image_alignment_table import ColKey
+
+        fm = self._file_manager()
+        if fm is None:
+            return
+
+        table.setRowCount(len(fm.names))
+        for i, name in enumerate(fm.names):
+            if ColKey.FOLDER in table._col:
+                label = (
+                    fm.source_labels[i]
+                    if getattr(fm, "source_labels", None) and i < len(fm.source_labels)
+                    else ""
+                )
+                folder_item = QTableWidgetItem(label)
+                folder_item.setToolTip(label)
+                table.setItem(i, table.col(ColKey.FOLDER), folder_item)
+
+            frame_item = QTableWidgetItem(os.path.basename(name))
+            frame_item.setToolTip(name)
+            table.setItem(i, table.col(ColKey.FRAME), frame_item)
+
+
 class CartesianRowMapper:
     """Reads the FM index from ``Qt.UserRole`` in a table column.
 

--- a/musclex/ui/widgets/__init__.py
+++ b/musclex/ui/widgets/__init__.py
@@ -9,6 +9,7 @@ from .image_viewer_widget import ImageViewerWidget
 from .image_navigator_widget import ImageNavigatorWidget
 from .processing_workspace import ProcessingWorkspace
 from .parameter_editor_table import ParameterEditorTable
+from .batch_folder_selection_dialog import BatchFolderSelectionDialog
 
 __all__ = [
     "NavigationControls",
@@ -22,4 +23,5 @@ __all__ = [
     "ImageNavigatorWidget",
     "ProcessingWorkspace",
     "ParameterEditorTable",
+    "BatchFolderSelectionDialog",
 ]

--- a/musclex/ui/widgets/batch_folder_selection_dialog.py
+++ b/musclex/ui/widgets/batch_folder_selection_dialog.py
@@ -1,0 +1,157 @@
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QVBoxLayout,
+)
+
+
+class BatchFolderSelectionDialog(QDialog):
+    def __init__(self, parent=None, start_dir=""):
+        super().__init__(parent)
+
+        self.setWindowTitle("Choose Batch Folders")
+        self.resize(760, 560)
+
+        self.start_dir = Path(start_dir or Path.home()).resolve()
+        self._updating_checks = False
+
+        layout = QVBoxLayout(self)
+
+        self.summaryLabel = QLabel("Select folders to process.")
+        layout.addWidget(self.summaryLabel)
+
+        buttonLayout = QHBoxLayout()
+
+        self.chooseRootButton = QPushButton("Choose Root Folder")
+        self.chooseRootButton.clicked.connect(self.choose_root_folder)
+        buttonLayout.addWidget(self.chooseRootButton)
+
+        self.clearButton = QPushButton("Clear")
+        self.clearButton.clicked.connect(self.clear_checks)
+        buttonLayout.addWidget(self.clearButton)
+
+        layout.addLayout(buttonLayout)
+
+        self.tree = QTreeWidget()
+        self.tree.setHeaderLabels(["Folder"])
+        self.tree.setColumnCount(1)
+        self.tree.itemExpanded.connect(self._on_item_expanded)
+        self.tree.itemChanged.connect(self._on_item_changed)
+        layout.addWidget(self.tree)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self.set_root_folder(self.start_dir)
+
+    def choose_root_folder(self):
+        folder = QFileDialog.getExistingDirectory(
+            self,
+            "Choose Parent Folder",
+            str(self.start_dir),
+        )
+        if folder:
+            self.set_root_folder(Path(folder).resolve())
+
+    def set_root_folder(self, folder):
+        self.start_dir = Path(folder).resolve()
+        self.tree.clear()
+
+        root_item = self._make_item(self.start_dir)
+        self.tree.addTopLevelItem(root_item)
+        self._populate_one_level(root_item)
+        root_item.setExpanded(True)
+
+        self._update_summary()
+
+    def selected_folders(self):
+        folders = []
+
+        def walk(item):
+            for i in range(item.childCount()):
+                child = item.child(i)
+                raw_path = child.data(0, Qt.UserRole)
+
+                if raw_path and child.checkState(0) == Qt.Checked:
+                    folders.append(Path(raw_path))
+
+                walk(child)
+
+        walk(self.tree.invisibleRootItem())
+        return sorted(set(folders))
+
+    def clear_checks(self):
+        self._updating_checks = True
+        try:
+            root = self.tree.invisibleRootItem()
+            self._set_checks_recursive(root, Qt.Unchecked)
+        finally:
+            self._updating_checks = False
+
+        self._update_summary()
+
+    def _make_item(self, path):
+        item = QTreeWidgetItem([path.name or str(path)])
+        item.setData(0, Qt.UserRole, str(path))
+        item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+        item.setCheckState(0, Qt.Unchecked)
+        item.setToolTip(0, str(path))
+        return item
+
+    def _child_dirs(self, path):
+        try:
+            return sorted(
+                [p for p in Path(path).iterdir() if p.is_dir()],
+                key=lambda p: p.name.lower(),
+            )
+        except Exception:
+            return []
+
+    def _populate_one_level(self, item):
+        if item.data(0, Qt.UserRole + 1) == "loaded":
+            return
+
+        path = Path(item.data(0, Qt.UserRole))
+        item.takeChildren()
+
+        for child_path in self._child_dirs(path):
+            child = self._make_item(child_path)
+            item.addChild(child)
+
+            if self._child_dirs(child_path):
+                placeholder = QTreeWidgetItem(["Loading..."])
+                placeholder.setData(0, Qt.UserRole, "")
+                child.addChild(placeholder)
+
+        item.setData(0, Qt.UserRole + 1, "loaded")
+
+    def _on_item_expanded(self, item):
+        self._populate_one_level(item)
+
+    def _on_item_changed(self, item, column):
+        if self._updating_checks or column != 0:
+            return
+
+        self._update_summary()
+
+    def _set_checks_recursive(self, item, state):
+        for i in range(item.childCount()):
+            child = item.child(i)
+            if child.data(0, Qt.UserRole):
+                child.setCheckState(0, state)
+            self._set_checks_recursive(child, state)
+
+    def _update_summary(self):
+        count = len(self.selected_folders())
+        self.summaryLabel.setText(f"{count} folder(s) selected.")

--- a/musclex/ui/widgets/image_alignment_table.py
+++ b/musclex/ui/widgets/image_alignment_table.py
@@ -34,6 +34,7 @@ class _ElideMiddleDelegate(QStyledItemDelegate):
 
 
 class ColKey:
+    FOLDER = "FOLDER"
     FRAME = "FRAME"
     CENTER = "CENTER"
     CENTER_MODE = "CENTER_MODE"

--- a/musclex/ui/widgets/image_alignment_widget.py
+++ b/musclex/ui/widgets/image_alignment_widget.py
@@ -84,12 +84,14 @@ class ImageAlignmentWidget(QWidget):
         worker_dir_path="",
         enable_symmetry_test=False,
         detection_button_position="top",
+        settings_resolver=None,
         parent=None,
     ):
         super().__init__(parent)
         self.workspace = workspace
         self._row_mapper = row_mapper
         self._worker_dir_path = worker_dir_path
+        self._settings_resolver = settings_resolver
         self._enable_symmetry_test = bool(enable_symmetry_test)
         if detection_button_position not in ("top", "bottom_after_thresholds"):
             detection_button_position = "top"
@@ -131,6 +133,7 @@ class ImageAlignmentWidget(QWidget):
         self.processExecutor = None
         self._in_batch = False
         self.stop_process = False
+        self._dirty_detection_settings = set()
 
         # Image-diff state
         self.diffTaskManager = ProcessingTaskManager()
@@ -376,12 +379,12 @@ class ImageAlignmentWidget(QWidget):
         self._row_geometry_cache = {}
         self.table.setRowCount(0)
         self._row_mapper.populate_table(self.table)
-        sm = self.workspace.settings_manager
         for row in range(self.table.rowCount()):
             name = self._row_mapper.name_for_row(row)
             if name is not None:
                 self._update_row_data(row, name)
-                if sm.has_ignore(name):
+                sm, key = self._settings_for_row(row, name)
+                if sm.has_ignore(key):
                     self._apply_ignore(row)
         self.table.resizeColumnsToContents()
 
@@ -410,9 +413,22 @@ class ImageAlignmentWidget(QWidget):
 
     def on_global_base_changed(self):
         """Re-read the global base from settings and refresh the table."""
-        base = self.workspace.settings_manager.get_global_base()
+        base = self._default_settings_manager().get_global_base()
         self._base_image_filename = base.get("base_image")
         self._update_table_data()
+
+    def _default_settings_manager(self):
+        return self.workspace.settings_manager
+
+    def _settings_for_row(self, row, name=None):
+        """Return ``(SettingsManager, image_key)`` for a table row."""
+        if name is None:
+            name = self._row_mapper.name_for_row(row)
+        if self._settings_resolver is not None:
+            resolved = self._settings_resolver(row, name)
+            if resolved is not None:
+                return resolved
+        return self._default_settings_manager(), name
 
     @property
     def ignored_rows(self) -> set:
@@ -446,19 +462,19 @@ class ImageAlignmentWidget(QWidget):
         """Refresh center/rotation data columns for a single row."""
         if row < 0 or row >= self.table.rowCount():
             return
-        sm = self.workspace.settings_manager
+        sm, key = self._settings_for_row(row, name)
 
-        manual_c = sm.get_center(name)
+        manual_c = sm.get_center(key)
         if manual_c is not None:
             self.table.fill_center(row, manual_c, "Manual")
         else:
-            auto_c = sm.get_auto_center(name)
+            auto_c = sm.get_auto_center(key)
             self.table.fill_center(row, auto_c, "Auto" if auto_c else None)
 
-        auto_center = sm.get_auto_center(name)
+        auto_center = sm.get_auto_center(key)
         self.table.fill_auto_center(row, auto_center)
 
-        effective_center = self._get_effective_center(name)
+        effective_center = self._get_effective_center(name, row)
         self.table.fill_auto_manual_dist(
             row,
             auto_center,
@@ -467,17 +483,17 @@ class ImageAlignmentWidget(QWidget):
             self._dist_threshold,
         )
 
-        manual_r = sm.get_rotation(name)
+        manual_r = sm.get_rotation(key)
         if manual_r is not None:
             self.table.fill_rotation(row, manual_r, "Manual")
         else:
-            auto_r = sm.get_auto_rotation(name)
+            auto_r = sm.get_auto_rotation(key)
             self.table.fill_rotation(row, auto_r, "Auto" if auto_r else None)
 
-        auto_rotation = sm.get_auto_rotation(name)
+        auto_rotation = sm.get_auto_rotation(key)
         self.table.fill_auto_rotation(row, auto_rotation)
 
-        effective_rotation = self._get_effective_rotation(name)
+        effective_rotation = self._get_effective_rotation(name, row)
         self.table.fill_auto_rot_diff(
             row,
             auto_rotation,
@@ -490,20 +506,20 @@ class ImageAlignmentWidget(QWidget):
             row,
             effective_center,
             effective_rotation,
-            self._get_base_center(),
-            self._get_base_rotation(),
+            self._get_base_center(row),
+            self._get_base_rotation(row),
         )
 
         self.table.fill_size(row, self._img_sizes.get(name, ""), self._most_common_size)
 
-        diff_val = sm.get_image_diff(name)
+        diff_val = sm.get_image_diff(key)
         self.table.fill_diff(
             row, diff_val, self._diff_thresh_enabled, self._diff_thresh_value
         )
 
         if self._enable_symmetry_test and ColKey.FOLD_STD in self.table._col:
             sym_val = (
-                sm.get_fold_std_sum(name) if hasattr(sm, "get_fold_std_sum") else None
+                sm.get_fold_std_sum(key) if hasattr(sm, "get_fold_std_sum") else None
             )
             self.table.fill_fold_std(
                 row,
@@ -513,7 +529,7 @@ class ImageAlignmentWidget(QWidget):
             )
         if self._enable_symmetry_test and ColKey.FOLD_STD_NORM in self.table._col:
             norm_val = (
-                sm.get_fold_std_norm(name) if hasattr(sm, "get_fold_std_norm") else None
+                sm.get_fold_std_norm(key) if hasattr(sm, "get_fold_std_norm") else None
             )
             self.table.fill_fold_std_norm(
                 row,
@@ -523,7 +539,7 @@ class ImageAlignmentWidget(QWidget):
             )
 
         self.table.apply_misaligned_highlight(row, name, self.misaligned_names)
-        self.table.apply_base_marker(row, name, self._base_image_filename)
+        self.table.apply_base_marker(row, key, sm.get_global_base().get("base_image"))
         if row in self._ignored_rows:
             self.table.dim_row(row)
 
@@ -539,27 +555,41 @@ class ImageAlignmentWidget(QWidget):
             if name is not None:
                 self._update_row_data(row, name)
 
-    def _get_effective_center(self, name):
+    def _get_effective_center(self, name, row=None):
         """Return (cx, cy) — manual if present, else auto, else None."""
-        sm = self.workspace.settings_manager
-        return sm.get_center(name) or sm.get_auto_center(name)
+        if row is not None:
+            sm, key = self._settings_for_row(row, name)
+        else:
+            sm, key = self._default_settings_manager(), name
+        return sm.get_center(key) or sm.get_auto_center(key)
 
-    def _get_effective_rotation(self, name):
+    def _get_effective_rotation(self, name, row=None):
         """Return rotation angle — manual if present, else auto, else None."""
-        sm = self.workspace.settings_manager
-        return sm.get_rotation(name) or sm.get_auto_rotation(name)
+        if row is not None:
+            sm, key = self._settings_for_row(row, name)
+        else:
+            sm, key = self._default_settings_manager(), name
+        return sm.get_rotation(key) or sm.get_auto_rotation(key)
 
-    def _get_base_center(self):
+    def _get_base_center(self, row=None):
         """Return the effective center of the global base image, or None."""
-        if not self._base_image_filename:
+        sm = self._default_settings_manager()
+        if row is not None:
+            sm, _key = self._settings_for_row(row)
+        base_image = sm.get_global_base().get("base_image") or self._base_image_filename
+        if not base_image:
             return None
-        return self._get_effective_center(self._base_image_filename)
+        return sm.get_center(base_image) or sm.get_auto_center(base_image)
 
-    def _get_base_rotation(self):
+    def _get_base_rotation(self, row=None):
         """Return the effective rotation of the global base image, or None."""
-        if not self._base_image_filename:
+        sm = self._default_settings_manager()
+        if row is not None:
+            sm, _key = self._settings_for_row(row)
+        base_image = sm.get_global_base().get("base_image") or self._base_image_filename
+        if not base_image:
             return None
-        return self._get_effective_rotation(self._base_image_filename)
+        return sm.get_rotation(base_image) or sm.get_auto_rotation(base_image)
 
     def _compute_most_common_size(self):
         """Count image sizes and cache the most frequent one."""
@@ -568,18 +598,28 @@ class ImageAlignmentWidget(QWidget):
         counts = Counter(s for s in self._img_sizes.values() if s)
         self._most_common_size = counts.most_common(1)[0][0] if counts else ""
 
+    def _settings_values(self, getter_name):
+        """Collect cached values across rows using the row-specific settings."""
+        values = []
+        for row in range(self._row_mapper.row_count()):
+            name = self._row_mapper.name_for_row(row)
+            if name is None:
+                continue
+            sm, key = self._settings_for_row(row, name)
+            getter = getattr(sm, getter_name, None)
+            if getter is None:
+                continue
+            value = getter(key)
+            if value is not None:
+                values.append(value)
+        return values
+
     def _compute_diff_percentile_threshold(self):
         """Compute the 80th-percentile of all cached diff values.
 
         Updates ``_diff_percentile_threshold`` and syncs the spinbox.
         """
-        sm = self.workspace.settings_manager
-        values = [
-            sm.get_image_diff(self._row_mapper.name_for_row(r))
-            for r in range(self._row_mapper.row_count())
-            if self._row_mapper.name_for_row(r) is not None
-        ]
-        values = [v for v in values if v is not None]
+        values = self._settings_values("get_image_diff")
         if len(values) >= 2:
             self._diff_percentile_threshold = float(np.percentile(values, 80))
             self._diff_thresh_spin.blockSignals(True)
@@ -602,15 +642,7 @@ class ImageAlignmentWidget(QWidget):
         """
         if not getattr(self, "_enable_symmetry_test", False):
             return
-        sm = self.workspace.settings_manager
-        if not hasattr(sm, "get_fold_std_sum"):
-            return
-        values = [
-            sm.get_fold_std_sum(self._row_mapper.name_for_row(r))
-            for r in range(self._row_mapper.row_count())
-            if self._row_mapper.name_for_row(r) is not None
-        ]
-        values = [v for v in values if v is not None]
+        values = self._settings_values("get_fold_std_sum")
         if len(values) >= 2:
             self._fold_std_percentile_threshold = float(np.percentile(values, 80))
             self._symmetry_thresh_spin.blockSignals(True)
@@ -630,15 +662,7 @@ class ImageAlignmentWidget(QWidget):
         """
         if not getattr(self, "_enable_symmetry_test", False):
             return
-        sm = self.workspace.settings_manager
-        if not hasattr(sm, "get_fold_std_norm"):
-            return
-        values = [
-            sm.get_fold_std_norm(self._row_mapper.name_for_row(r))
-            for r in range(self._row_mapper.row_count())
-            if self._row_mapper.name_for_row(r) is not None
-        ]
-        values = [v for v in values if v is not None]
+        values = self._settings_values("get_fold_std_norm")
         if len(values) >= 2:
             self._fold_std_norm_percentile_threshold = float(np.percentile(values, 80))
             self._norm_thresh_spin.blockSignals(True)
@@ -753,8 +777,8 @@ class ImageAlignmentWidget(QWidget):
         if name is None:
             return
         self._ignored_rows.add(row)
-        sm = self.workspace.settings_manager
-        sm.set_ignore(name)
+        sm, key = self._settings_for_row(row, name)
+        sm.set_ignore(key)
         sm.save_ignore()
         print(f"Ignore: {name}")
         self.table.dim_row(row)
@@ -767,8 +791,8 @@ class ImageAlignmentWidget(QWidget):
         if name is None:
             return
         self._ignored_rows.discard(row)
-        sm = self.workspace.settings_manager
-        sm.clear_ignore(name)
+        sm, key = self._settings_for_row(row, name)
+        sm.clear_ignore(key)
         sm.save_ignore()
         print(f"Cancel Ignore: {name}")
         normal = QBrush(self.table.palette().color(self.table.foregroundRole()))
@@ -831,8 +855,9 @@ class ImageAlignmentWidget(QWidget):
             r = selected_rows[0]
             img_name = self._row_mapper.name_for_row(r)
             if img_name is not None:
-                self.workspace.settings_manager.set_global_base(img_name)
-                self.workspace.settings_manager.save_global_base()
+                sm, key = self._settings_for_row(r, img_name)
+                sm.set_global_base(key)
+                sm.save_global_base()
                 self.on_global_base_changed()
                 self.globalBaseChanged.emit()
 
@@ -993,9 +1018,9 @@ class ImageAlignmentWidget(QWidget):
                 if fm_idx is not None and fm_idx < len(fm.specs)
                 else None
             )
-            manual_center, manual_rotation = self.workspace.get_manual_settings(
-                img_name
-            )
+            sm, key = self._settings_for_row(row, img_name)
+            manual_center = sm.get_center(key)
+            manual_rotation = sm.get_rotation(key)
             if self._batch_do_symmetry:
                 job_args = (
                     self._worker_dir_path,
@@ -1054,21 +1079,25 @@ class ImageAlignmentWidget(QWidget):
             # the cancel arrives is not silently lost. ``_on_batch_complete``
             # writes the cache to disk regardless of stop state.
             if not error:
-                sm = self.workspace.settings_manager
+                sm, key = self._settings_for_row(task.job_index, task.filename)
                 sm.set_auto_cache(
-                    task.filename,
+                    key,
                     result["center"],
                     result["rotation"],
                 )
+                sm.save_auto_cache()
+                self._dirty_detection_settings.add(sm)
                 # Persist the fold-symmetry scores when present (only emitted by
                 # the symmetry-aware worker). ``None`` simply means the symmetry
                 # test was not requested for this image.
                 fold_std = result.get("fold_std_sum")
                 if fold_std is not None and hasattr(sm, "set_fold_std_sum"):
-                    sm.set_fold_std_sum(task.filename, fold_std)
+                    sm.set_fold_std_sum(key, fold_std)
+                    sm.save_fold_std_sum()
                 fold_norm = result.get("fold_std_norm")
                 if fold_norm is not None and hasattr(sm, "set_fold_std_norm"):
-                    sm.set_fold_std_norm(task.filename, fold_norm)
+                    sm.set_fold_std_norm(key, fold_norm)
+                    sm.save_fold_std_norm()
 
             # When the user asked to stop, leave UI updates and the completion
             # check to the stopProcess state machine; data was already cached
@@ -1106,13 +1135,14 @@ class ImageAlignmentWidget(QWidget):
         # the batch ran to completion or was interrupted via Stop. Without
         # this, partial-but-valid results from a stopped run would be lost
         # because ``_on_batch_result`` only writes to the in-memory cache.
-        sm = self.workspace.settings_manager
-        sm.save_auto_cache()
         ran_symmetry = getattr(self, "_batch_do_symmetry", False)
-        if ran_symmetry and hasattr(sm, "save_fold_std_sum"):
-            sm.save_fold_std_sum()
-        if ran_symmetry and hasattr(sm, "save_fold_std_norm"):
-            sm.save_fold_std_norm()
+        for sm in list(self._dirty_detection_settings):
+            sm.save_auto_cache()
+            if ran_symmetry and hasattr(sm, "save_fold_std_sum"):
+                sm.save_fold_std_sum()
+            if ran_symmetry and hasattr(sm, "save_fold_std_norm"):
+                sm.save_fold_std_norm()
+        self._dirty_detection_settings.clear()
         # When the batch ran with the symmetry test enabled, derive a sensible
         # default highlight threshold (80th percentile of all scores) and push
         # it into the spinbox so flagged rows light up without manual tuning.
@@ -1160,7 +1190,17 @@ class ImageAlignmentWidget(QWidget):
         if row < 0 or row >= self.table.rowCount():
             return False
         name = self._row_mapper.name_for_row(row)
-        return name is not None and self._get_effective_center(name) is not None
+        return name is not None and self._get_effective_center(name, row) is not None
+
+    def _rows_share_settings_scope(self, row_a, row_b):
+        """Return True when two rows belong to the same settings manager."""
+        name_a = self._row_mapper.name_for_row(row_a)
+        name_b = self._row_mapper.name_for_row(row_b)
+        if name_a is None or name_b is None:
+            return False
+        sm_a, _key_a = self._settings_for_row(row_a, name_a)
+        sm_b, _key_b = self._settings_for_row(row_b, name_b)
+        return sm_a is sm_b
 
     def _trigger_diff_for_row(self, row):
         """Recompute the (at most) two diff pairs that involve *row*."""
@@ -1181,6 +1221,8 @@ class ImageAlignmentWidget(QWidget):
 
         for idx_a, idx_b in pairs:
             if (idx_a, idx_b) in self._diff_pairs_in_flight:
+                continue
+            if not self._rows_share_settings_scope(idx_a, idx_b):
                 continue
             if not self._row_has_geometry(idx_a) or not self._row_has_geometry(idx_b):
                 continue
@@ -1223,8 +1265,8 @@ class ImageAlignmentWidget(QWidget):
             return
         fm_idx_a = self._row_mapper.fm_index_for_row(idx_a)
         fm_idx_b = self._row_mapper.fm_index_for_row(idx_b)
-        base_center = self._get_base_center()
-        base_rotation = self._get_base_rotation()
+        base_center = self._get_base_center(idx_b)
+        base_rotation = self._get_base_rotation(idx_b)
 
         job_args = (
             self._worker_dir_path,
@@ -1240,10 +1282,10 @@ class ImageAlignmentWidget(QWidget):
                 if fm_idx_b is not None and fm_idx_b < len(fm.specs)
                 else None
             ),
-            self._get_effective_center(name_a),
-            self._get_effective_rotation(name_a),
-            self._get_effective_center(name_b),
-            self._get_effective_rotation(name_b),
+            self._get_effective_center(name_a, idx_a),
+            self._get_effective_rotation(name_a, idx_a),
+            self._get_effective_center(name_b, idx_b),
+            self._get_effective_rotation(name_b, idx_b),
             list(base_center) if base_center else None,
             base_rotation,
             idx_b,
@@ -1281,13 +1323,14 @@ class ImageAlignmentWidget(QWidget):
             if error:
                 print(f"Diff error for pair ({idx_a}, {idx_b}): {error}")
             elif name_b is not None:
-                sm = self.workspace.settings_manager
-                sm.set_image_diff(name_b, result["diff"])
+                sm, key = self._settings_for_row(idx_b, name_b)
+                sm.set_image_diff(key, result["diff"])
                 sm.save_image_diff()
                 self._compute_diff_percentile_threshold()
 
             if name_b is not None and idx_b < self.table.rowCount():
-                diff_val = self.workspace.settings_manager.get_image_diff(name_b)
+                sm, key = self._settings_for_row(idx_b, name_b)
+                diff_val = sm.get_image_diff(key)
                 self.table.fill_diff(
                     idx_b,
                     diff_val,

--- a/musclex/ui/widgets/navigation_controls.py
+++ b/musclex/ui/widgets/navigation_controls.py
@@ -1,4 +1,10 @@
-from PySide6.QtWidgets import QWidget, QPushButton, QGridLayout, QLineEdit
+from PySide6.QtWidgets import (
+    QWidget,
+    QPushButton,
+    QGridLayout,
+    QLineEdit,
+    QCheckBox,
+)
 
 
 class NavigationControls(QWidget):
@@ -35,6 +41,25 @@ class NavigationControls(QWidget):
         self.processH5Button.setCheckable(checkable_process_h5)
         self.processH5Button.setStyleSheet(process_button_style)
 
+        # Batch processing options (initially hidden, can be shown by parent GUIs)
+        self.batchScopeWidget = QWidget()
+        self.batchScopeLayout = QGridLayout(self.batchScopeWidget)
+        self.batchScopeLayout.setContentsMargins(0, 0, 0, 0)
+
+        self.process_sibling_folder_checkbox = QCheckBox("Sibling folders")
+        self.process_sibling_folder_checkbox.setToolTip(
+            "Also process folders next to the current folder."
+        )
+        self.process_recursively_checkbox = QCheckBox("Recursive")
+        self.process_recursively_checkbox.setToolTip(
+            "Also process image folders inside the selected folder scope."
+        )
+        self.batchScopeLayout.addWidget(self.process_sibling_folder_checkbox, 0, 0)
+        self.batchScopeLayout.addWidget(self.process_recursively_checkbox, 0, 1)
+        self.batchScopeLayout.setColumnStretch(0, 1)
+        self.batchScopeLayout.setColumnStretch(1, 1)
+        self.batchScopeWidget.hide()
+
         self.prevButton = QPushButton("<")
         self.nextButton = QPushButton(">")
         self.prevFileButton = QPushButton("<<<")
@@ -59,6 +84,8 @@ class NavigationControls(QWidget):
         layout.addWidget(self.processFolderButton, row, 0, 1, 2)
         row += 1
         layout.addWidget(self.processH5Button, row, 0, 1, 2)
+        row += 1
+        layout.addWidget(self.batchScopeWidget, row, 0, 1, 2)
         row += 1
 
         layout.addWidget(self.prevButton, row, 0, 1, 1)
@@ -85,3 +112,26 @@ class NavigationControls(QWidget):
             self.nextFileButton.hide()
             self.prevFileButton.hide()
             self.processH5Button.hide()
+
+    def set_batch_scope_visible(self, visible):
+        """
+        Show or hide the batch processing scope options.
+        """
+        self.batchScopeWidget.setVisible(visible)
+
+        if not visible:
+            # Reset checkboxes when hiding
+            self.process_sibling_folder_checkbox.setChecked(False)
+            self.process_recursively_checkbox.setChecked(False)
+
+    def process_sibling_folders_enabled(self) -> bool:
+        return (
+            self.batchScopeWidget.isVisible()
+            and self.process_sibling_folder_checkbox.isChecked()
+        )
+
+    def process_recursively_enabled(self) -> bool:
+        return (
+            self.batchScopeWidget.isVisible()
+            and self.process_recursively_checkbox.isChecked()
+        )

--- a/musclex/ui/widgets/navigation_controls.py
+++ b/musclex/ui/widgets/navigation_controls.py
@@ -54,10 +54,18 @@ class NavigationControls(QWidget):
         self.process_recursively_checkbox.setToolTip(
             "Also process image folders inside the selected folder scope."
         )
+
+        self.cache_checkbox = QCheckBox("Cache Settings")
+        self.cache_checkbox.setToolTip(
+            "Save qfsettings.json automatically when processing the folder."
+        )
+
         self.batchScopeLayout.addWidget(self.process_sibling_folder_checkbox, 0, 0)
         self.batchScopeLayout.addWidget(self.process_recursively_checkbox, 0, 1)
+        self.batchScopeLayout.addWidget(self.cache_checkbox, 0, 2)
         self.batchScopeLayout.setColumnStretch(0, 1)
         self.batchScopeLayout.setColumnStretch(1, 1)
+        self.batchScopeLayout.setColumnStretch(2, 1)
         self.batchScopeWidget.hide()
 
         self.prevButton = QPushButton("<")
@@ -123,6 +131,7 @@ class NavigationControls(QWidget):
             # Reset checkboxes when hiding
             self.process_sibling_folder_checkbox.setChecked(False)
             self.process_recursively_checkbox.setChecked(False)
+            self.cache_checkbox.setChecked(False)
 
     def process_sibling_folders_enabled(self) -> bool:
         return (
@@ -135,3 +144,6 @@ class NavigationControls(QWidget):
             self.batchScopeWidget.isVisible()
             and self.process_recursively_checkbox.isChecked()
         )
+
+    def cache_enabled(self) -> bool:
+        return self.batchScopeWidget.isVisible() and self.cache_checkbox.isChecked()

--- a/musclex/ui/widgets/navigation_controls.py
+++ b/musclex/ui/widgets/navigation_controls.py
@@ -31,6 +31,7 @@ class NavigationControls(QWidget):
         parent=None,
     ):
         super().__init__(parent)
+        self.default_process_folder_text = process_folder_text
 
         # Controls
         self.processFolderButton = QPushButton(process_folder_text)
@@ -41,32 +42,39 @@ class NavigationControls(QWidget):
         self.processH5Button.setCheckable(checkable_process_h5)
         self.processH5Button.setStyleSheet(process_button_style)
 
-        # Batch processing options (initially hidden, can be shown by parent GUIs)
-        self.batchScopeWidget = QWidget()
-        self.batchScopeLayout = QGridLayout(self.batchScopeWidget)
-        self.batchScopeLayout.setContentsMargins(0, 0, 0, 0)
+        # # Batch processing options (initially hidden, can be shown by parent GUIs)
+        # self.batchScopeWidget = QWidget()
+        # self.batchScopeLayout = QGridLayout(self.batchScopeWidget)
+        # self.batchScopeLayout.setContentsMargins(0, 0, 0, 0)
 
-        self.process_sibling_folder_checkbox = QCheckBox("Sibling folders")
-        self.process_sibling_folder_checkbox.setToolTip(
-            "Also process folders next to the current folder."
+        self.select_batch_folder_button = QPushButton("Choose Batch Folders")
+        self.select_batch_folder_button.setToolTip(
+            "Choose one or more folders to process with the current settings."
         )
-        self.process_recursively_checkbox = QCheckBox("Recursive")
-        self.process_recursively_checkbox.setToolTip(
-            "Also process image folders inside the selected folder scope."
-        )
+        self.select_batch_folder_button.hide()
+        # self.batchScopeLayout.addWidget(self.select_batch_folder_button, 0, 0, 1, 3)
 
-        self.cache_checkbox = QCheckBox("Cache Settings")
-        self.cache_checkbox.setToolTip(
-            "Save qfsettings.json automatically when processing the folder."
-        )
+        # self.process_sibling_folder_checkbox = QCheckBox("Sibling folders")
+        # self.process_sibling_folder_checkbox.setToolTip(
+        #     "Also process folders next to the current folder."
+        # )
+        # self.process_recursively_checkbox = QCheckBox("Recursive")
+        # self.process_recursively_checkbox.setToolTip(
+        #     "Also process image folders inside the selected folder scope."
+        # )
 
-        self.batchScopeLayout.addWidget(self.process_sibling_folder_checkbox, 0, 0)
-        self.batchScopeLayout.addWidget(self.process_recursively_checkbox, 0, 1)
-        self.batchScopeLayout.addWidget(self.cache_checkbox, 0, 2)
-        self.batchScopeLayout.setColumnStretch(0, 1)
-        self.batchScopeLayout.setColumnStretch(1, 1)
-        self.batchScopeLayout.setColumnStretch(2, 1)
-        self.batchScopeWidget.hide()
+        # self.cache_checkbox = QCheckBox("Cache Settings")
+        # self.cache_checkbox.setToolTip(
+        #     "Save qfsettings.json automatically when processing the folder."
+        # )
+
+        # self.batchScopeLayout.addWidget(self.process_sibling_folder_checkbox, 0, 0)
+        # self.batchScopeLayout.addWidget(self.process_recursively_checkbox, 0, 1)
+        # self.batchScopeLayout.addWidget(self.cache_checkbox, 0, 2)
+        # self.batchScopeLayout.setColumnStretch(0, 1)
+        # self.batchScopeLayout.setColumnStretch(1, 1)
+        # self.batchScopeLayout.setColumnStretch(2, 1)
+        # self.batchScopeWidget.hide()
 
         self.prevButton = QPushButton("<")
         self.nextButton = QPushButton(">")
@@ -89,11 +97,11 @@ class NavigationControls(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
 
         row = 0
+        layout.addWidget(self.select_batch_folder_button, row, 0, 1, 2)
+        row += 1
         layout.addWidget(self.processFolderButton, row, 0, 1, 2)
         row += 1
         layout.addWidget(self.processH5Button, row, 0, 1, 2)
-        row += 1
-        layout.addWidget(self.batchScopeWidget, row, 0, 1, 2)
         row += 1
 
         layout.addWidget(self.prevButton, row, 0, 1, 1)
@@ -121,29 +129,20 @@ class NavigationControls(QWidget):
             self.prevFileButton.hide()
             self.processH5Button.hide()
 
-    def set_batch_scope_visible(self, visible):
+    def set_select_batch_folder_visible(self, visible):
         """
-        Show or hide the batch processing scope options.
+        Show or hide the "Choose Batch Folders" button.
         """
-        self.batchScopeWidget.setVisible(visible)
+        self.select_batch_folder_button.setVisible(visible)
 
-        if not visible:
-            # Reset checkboxes when hiding
-            self.process_sibling_folder_checkbox.setChecked(False)
-            self.process_recursively_checkbox.setChecked(False)
-            self.cache_checkbox.setChecked(False)
+    def reset_process_folder_text(self):
+        """
+        Reset the process folder button text to the default.
+        """
+        self.processFolderButton.setText(self.default_process_folder_text)
 
-    def process_sibling_folders_enabled(self) -> bool:
-        return (
-            self.batchScopeWidget.isVisible()
-            and self.process_sibling_folder_checkbox.isChecked()
-        )
-
-    def process_recursively_enabled(self) -> bool:
-        return (
-            self.batchScopeWidget.isVisible()
-            and self.process_recursively_checkbox.isChecked()
-        )
-
-    def cache_enabled(self) -> bool:
-        return self.batchScopeWidget.isVisible() and self.cache_checkbox.isChecked()
+    def reset_batch_folder_button_text(self):
+        """
+        Reset the batch folder button text to the default.
+        """
+        self.select_batch_folder_button.setText("Choose Batch Folders")

--- a/musclex/ui/widgets/processing_workspace.py
+++ b/musclex/ui/widgets/processing_workspace.py
@@ -146,6 +146,8 @@ class ProcessingWorkspace(QWidget):
         # Orientation model and mode rotation state
         self._orientation_model = 0  # Default: Max Intensity
         self._mode_rotation = None  # Cached mode rotation value
+        self._batch_all_center = None
+        self._batch_all_rotation = None
 
         # Centralized settings I/O
         self.settings_manager = SettingsManager(settings_dir)
@@ -674,6 +676,9 @@ class ProcessingWorkspace(QWidget):
             )
             return
 
+        if scope == "all":
+            self._batch_all_center = tuple(center)
+
         self.apply_center_to_batch(center, scope)
 
         QMessageBox.information(
@@ -685,6 +690,9 @@ class ProcessingWorkspace(QWidget):
     def _on_restore_auto_center(self, scope: str):
         """Handle Restore Auto Center."""
         from PySide6.QtWidgets import QMessageBox
+
+        if scope == "all":
+            self._batch_all_center = None
 
         self.restore_auto_center_for_batch(scope)
 
@@ -711,6 +719,9 @@ class ProcessingWorkspace(QWidget):
             )
             return
 
+        if scope == "all":
+            self._batch_all_rotation = rotation
+
         self.apply_rotation_to_batch(rotation, scope)
 
         QMessageBox.information(
@@ -722,6 +733,9 @@ class ProcessingWorkspace(QWidget):
     def _on_restore_auto_rotation(self, scope: str):
         """Handle Restore Auto Rotation."""
         from PySide6.QtWidgets import QMessageBox
+
+        if scope == "all":
+            self._batch_all_rotation = None
 
         self.restore_auto_rotation_for_batch(scope)
 
@@ -840,6 +854,17 @@ class ProcessingWorkspace(QWidget):
         center = self.settings_manager.get_center(filename)
         rotation = self.settings_manager.get_rotation(filename)
         return center, rotation
+
+    def get_batch_all_geometry(
+        self,
+    ) -> Tuple[Optional[Tuple[float, float]], Optional[float]]:
+        """Return geometry captured from Apply Center/Rotation -> all images."""
+        return self._batch_all_center, self._batch_all_rotation
+
+    def clear_batch_all_geometry(self):
+        """Clear batch-wide geometry captured from Apply Center/Rotation."""
+        self._batch_all_center = None
+        self._batch_all_rotation = None
 
     def save_settings(self):
         """Save all settings to JSON files."""

--- a/musclex/utils/file_manager.py
+++ b/musclex/utils/file_manager.py
@@ -1387,3 +1387,8 @@ def scan_directory_files_sync(dir_path):
 
     files.sort(key=lambda x: x[0])
     return files
+
+
+def is_exclude_scan_dir(dir_path):
+    name = os.path.basename(str(dir_path).rstrip("/\\")).lower()
+    return name == "settings" or name.endswith("_results") or name.endswith("_cache")

--- a/musclex/utils/settings_manager.py
+++ b/musclex/utils/settings_manager.py
@@ -41,7 +41,7 @@ authorization from Illinois Institute of Technology.
 import json
 import pickle
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 
 class SettingsManager:
@@ -373,17 +373,49 @@ class SettingsManager:
 
     # ===== Calibration =====
 
+    @staticmethod
+    def load_calibration_cache_file(
+        path: Union[str, Path], require_settings: bool = False
+    ) -> Optional[dict]:
+        """
+        Load a calibration cache pickle from an explicit file path.
+
+        Args:
+            path: Path to a MuscleX ``calibration.info`` cache.
+            require_settings: When True, reject caches without a non-empty
+                ``settings`` dict. This is useful for user-selected imports.
+
+        Returns:
+            The calibration cache dict, or None when the file is absent.
+
+        Raises:
+            ValueError: The file exists but is not a valid calibration cache.
+            OSError/pickle.PickleError/etc.: The file cannot be read/unpickled.
+        """
+        cache_path = Path(path)
+        if not cache_path.exists():
+            return None
+
+        with open(cache_path, "rb") as f:
+            cache = pickle.load(f)
+
+        if not isinstance(cache, dict) or "version" not in cache:
+            raise ValueError("The selected file is not a valid calibration cache.")
+
+        if require_settings and not cache.get("settings"):
+            raise ValueError(
+                "The selected file does not contain saved calibration settings."
+            )
+
+        return cache
+
     def load_calibration_cache(self) -> Optional[dict]:
         """Load ``calibration.info`` (pickle). Returns the cache dict or None."""
         path = self.settings_path / "calibration.info"
-        if path.exists():
-            try:
-                with open(path, "rb") as f:
-                    cache = pickle.load(f)
-                if cache is not None and "version" in cache:
-                    return cache
-            except Exception as e:
-                print(f"Warning: Failed to load calibration cache: {e}")
+        try:
+            return self.load_calibration_cache_file(path)
+        except Exception as e:
+            print(f"Warning: Failed to load calibration cache: {e}")
         return None
 
     def save_calibration_cache(self, cache: dict):


### PR DESCRIPTION
## Summary

- Add optional Quadrant Folding batch controls for processing sibling folders and recursive folder scopes.
- Collect image sources across the selected folder scope while skipping generated/settings folders.
- Preserve per-source output behavior so QF results, CSV summaries, and background metrics are written back under each source/output directory.
- Update multiprocessing QF jobs to carry `save_name` and `output_dir` through worker results.
- Add per-output CSV manager handling for multi-folder batch runs.
