### PR TITLE
Detector Identification

### DIFF
--- a/musclex/CalibrationSettings/CalibrationSettings.py
+++ b/musclex/CalibrationSettings/CalibrationSettings.py
@@ -45,6 +45,8 @@ class CalibrationSettings(QDialog):
     The CalibrationSettings object is a window and functions helping the software to calibrate the images processed and improve the results found.
     """
 
+    KEV_NM = 1.239841984
+
     def __init__(
         self,
         dir_path,
@@ -126,6 +128,7 @@ class CalibrationSettings(QDialog):
         """
         silverb = 5.83803
         init_lambda = 0.1033
+        init_energy = self.energy_from_wavelength(init_lambda)
         init_sdd = 2500
         init_pix_size = 0.0
         typ = None
@@ -135,6 +138,9 @@ class CalibrationSettings(QDialog):
             typ = self.calSettings["type"] if "type" in self.calSettings else None
             if typ == "cont":
                 init_lambda = self.calSettings["lambda"]
+                init_energy = self.calSettings.get(
+                    "beam_energy", self.energy_from_wavelength(init_lambda)
+                )
                 init_sdd = self.calSettings["sdd"]
                 init_pix_size = self.calSettings["pixel_size"]
                 self.pixel_size_user_confirmed = True
@@ -197,7 +203,8 @@ class CalibrationSettings(QDialog):
         )
         self.buttons.accepted.connect(self.okClicked)
         self.buttons.rejected.connect(self.reject)
-        self.buttons.setFixedWidth(100)
+        for button in self.buttons.buttons():
+            button.setMinimumWidth(90)
         # grpbox_ss = "QGroupBox::title { background-color: #323232 ; subcontrol-origin: margin; subcontrol-position: top left; padding: 0 3px; }"
         self.calImageGrp = QGroupBox("Setting by Calibration Image")
         self.calImageGrp.setCheckable(False)
@@ -241,6 +248,13 @@ class CalibrationSettings(QDialog):
         self.lambdaSpnBx.setValue(init_lambda)
         self.lambdaSpnBx.setObjectName("lambdaSpnBx")
         self.editableVars[self.lambdaSpnBx.objectName()] = None
+
+        self.energySpnBx = QDoubleSpinBox()
+        self.energySpnBx.setDecimals(8)
+        self.energySpnBx.setRange(0.00001, 1000.0)
+        self.energySpnBx.setValue(init_energy)
+        self.energySpnBx.setObjectName("energySpnBx")
+        self.editableVars[self.energySpnBx.objectName()] = None
 
         self.sddSpnBx = QDoubleSpinBox()
         self.sddSpnBx.setDecimals(8)
@@ -315,12 +329,15 @@ class CalibrationSettings(QDialog):
         self.paramLayout.addWidget(QLabel("Lambda : "), 0, 0, 1, 1)
         self.paramLayout.addWidget(self.lambdaSpnBx, 0, 1, 1, 1)
         self.paramLayout.addWidget(QLabel("nm"), 0, 2, 1, 1)
-        self.paramLayout.addWidget(QLabel("S<sub>dd</sub> : "), 1, 0, 1, 1)
-        self.paramLayout.addWidget(self.sddSpnBx, 1, 1, 1, 1)
-        self.paramLayout.addWidget(QLabel("mm"), 1, 2, 1, 1)
-        self.paramLayout.addWidget(QLabel("Pixel Size : "), 2, 0, 1, 1)
-        self.paramLayout.addWidget(self.pixsSpnBx, 2, 1, 1, 1)
+        self.paramLayout.addWidget(QLabel("Beam Energy : "), 1, 0, 1, 1)
+        self.paramLayout.addWidget(self.energySpnBx, 1, 1, 1, 1)
+        self.paramLayout.addWidget(QLabel("keV"), 1, 2, 1, 1)
+        self.paramLayout.addWidget(QLabel("S<sub>dd</sub> : "), 2, 0, 1, 1)
+        self.paramLayout.addWidget(self.sddSpnBx, 2, 1, 1, 1)
         self.paramLayout.addWidget(QLabel("mm"), 2, 2, 1, 1)
+        self.paramLayout.addWidget(QLabel("Pixel Size : "), 3, 0, 1, 1)
+        self.paramLayout.addWidget(self.pixsSpnBx, 3, 1, 1, 1)
+        self.paramLayout.addWidget(QLabel("mm"), 3, 2, 1, 1)
 
         self.mainLayout.addWidget(self.calImageGrpChkBox)
         self.mainLayout.addWidget(self.calImageGrp)
@@ -380,6 +397,9 @@ class CalibrationSettings(QDialog):
         self.lambdaSpnBx.editingFinished.connect(
             lambda: self.settingChanged("lambda", self.lambdaSpnBx)
         )
+        self.energySpnBx.editingFinished.connect(
+            lambda: self.settingChanged("energy", self.energySpnBx)
+        )
         self.sddSpnBx.editingFinished.connect(
             lambda: self.settingChanged("sdd", self.sddSpnBx)
         )
@@ -419,12 +439,38 @@ class CalibrationSettings(QDialog):
         """
         Change the log when the settings are changed.
         """
-        if name == "pixS" and obj.value() > 0:
+        if name == "lambda":
+            self.update_energy_from_wavelength()
+        elif name == "energy":
+            self.update_wavelength_from_energy()
+        elif name == "pixS" and obj.value() > 0:
             self.pixel_size_user_confirmed = True
             self.pixel_size_source = "manual"
         elif name == "detector" and self.manDetector.isChecked():
             self._apply_manual_detector_metadata()
         self.log_changes(name, obj)
+
+    @classmethod
+    def energy_from_wavelength(cls, wavelength_nm):
+        if wavelength_nm <= 0:
+            return 0.0
+        return cls.KEV_NM / wavelength_nm
+
+    @classmethod
+    def wavelength_from_energy(cls, energy_kev):
+        if energy_kev <= 0:
+            return 0.0
+        return cls.KEV_NM / energy_kev
+
+    def update_energy_from_wavelength(self):
+        energy = self.energy_from_wavelength(self.lambdaSpnBx.value())
+        if energy > 0:
+            self.energySpnBx.setValue(energy)
+
+    def update_wavelength_from_energy(self):
+        wavelength = self.wavelength_from_energy(self.energySpnBx.value())
+        if wavelength > 0:
+            self.lambdaSpnBx.setValue(wavelength)
 
     def decalibrate(self):
         """
@@ -696,6 +742,12 @@ class CalibrationSettings(QDialog):
             self.calImageGrpChkBox.setChecked(False)
             self.calImageGrp.setEnabled(False)
             self.lambdaSpnBx.setValue(settings.get("lambda", self.lambdaSpnBx.value()))
+            self.energySpnBx.setValue(
+                settings.get(
+                    "beam_energy",
+                    self.energy_from_wavelength(self.lambdaSpnBx.value()),
+                )
+            )
             self.sddSpnBx.setValue(settings.get("sdd", self.sddSpnBx.value()))
             self.pixsSpnBx.setValue(settings.get("pixel_size", self.pixsSpnBx.value()))
             self.manualCal.setEnabled(False)
@@ -777,6 +829,7 @@ class CalibrationSettings(QDialog):
 
             self.calSettings = {
                 "lambda": self.lambdaSpnBx.value(),
+                "beam_energy": self.energySpnBx.value(),
                 "pixel_size": pixel_size,
                 "sdd": self.sddSpnBx.value(),
                 "scale": (self.lambdaSpnBx.value() * self.sddSpnBx.value())

--- a/musclex/CalibrationSettings/CalibrationSettings.py
+++ b/musclex/CalibrationSettings/CalibrationSettings.py
@@ -33,6 +33,7 @@ import matplotlib.patches as patches
 import fabio
 import musclex
 import numpy as np
+from pyFAI import detector_factory
 from pyFAI.detectors import Detector
 from ..ui.pyqt_utils import *
 from ..utils.file_manager import fullPath, ifHdfReadConvertless
@@ -79,12 +80,16 @@ class CalibrationSettings(QDialog):
         self.doubleZoomPt = (0, 0)
         self.doubleZoomAxes = None
         self.cal_img = None
+        self.cal_fabio_img = None
         self.disp_img = None
         self.ax = None
         self.ax2 = None
         self.version = musclex.__version__
         self.uiUpdating = False
         self.quadrant_folded = quadrant_folded
+        self.detector_metadata = {}
+        self.pixel_size_source = None
+        self.pixel_size_user_confirmed = False
 
         # Initialize with provided settings or defaults
         if initial_settings is not None:
@@ -122,7 +127,7 @@ class CalibrationSettings(QDialog):
         silverb = 5.83803
         init_lambda = 0.1033
         init_sdd = 2500
-        init_pix_size = 0.172
+        init_pix_size = 0.0
         typ = None
         center = None
         detector = None
@@ -132,6 +137,7 @@ class CalibrationSettings(QDialog):
                 init_lambda = self.calSettings["lambda"]
                 init_sdd = self.calSettings["sdd"]
                 init_pix_size = self.calSettings["pixel_size"]
+                self.pixel_size_user_confirmed = True
             elif typ == "img":
                 silverb = self.calSettings["silverB"]
 
@@ -139,6 +145,10 @@ class CalibrationSettings(QDialog):
                 center = self.calSettings["center"]
             if "detector" in self.calSettings:
                 detector = self.calSettings["detector"]
+            if "pixel_size_source" in self.calSettings:
+                self.pixel_size_source = self.calSettings["pixel_size_source"]
+            if "detector_metadata" in self.calSettings:
+                self.detector_metadata = self.calSettings["detector_metadata"]
 
         self.mainLayout = QVBoxLayout(self)
 
@@ -241,7 +251,8 @@ class CalibrationSettings(QDialog):
 
         self.pixsSpnBx = QDoubleSpinBox()
         self.pixsSpnBx.setDecimals(8)
-        self.pixsSpnBx.setRange(0.00001, 5.0)
+        self.pixsSpnBx.setRange(0.0, 5.0)
+        self.pixsSpnBx.setSpecialValueText("Unknown")
         self.pixsSpnBx.setValue(init_pix_size)
         self.pixsSpnBx.setObjectName("pixsSpnBx")
         self.editableVars[self.pixsSpnBx.objectName()] = None
@@ -408,6 +419,9 @@ class CalibrationSettings(QDialog):
         """
         Change the log when the settings are changed.
         """
+        if name == "pixS" and obj.value() > 0:
+            self.pixel_size_user_confirmed = True
+            self.pixel_size_source = "manual"
         self.log_changes(name, obj)
 
     def decalibrate(self):
@@ -604,6 +618,7 @@ class CalibrationSettings(QDialog):
         file_name = getAFile(parent=self)
         if file_name != "" and exists(str(file_name)):
             self.cal_img = None
+            self.cal_fabio_img = None
             self.calFile = str(file_name)
             self.pathText.setText(str(file_name))
             self.manualCal.setEnabled(True)
@@ -657,9 +672,13 @@ class CalibrationSettings(QDialog):
         self.calFile = str(cal_path)
         self.pathText.setText(self.calFile if exists(self.calFile) else "")
         self.cal_img = None
+        self.cal_fabio_img = None
         self.disp_img = None
         self.refined_points = None
         self._last_user_points = None
+        self.detector_metadata = settings.get("detector_metadata", {})
+        self.pixel_size_source = settings.get("pixel_size_source")
+        self.pixel_size_user_confirmed = "pixel_size" in settings
 
         if cal_type == "img":
             self.calImageGrpChkBox.setChecked(True)
@@ -737,14 +756,33 @@ class CalibrationSettings(QDialog):
             self.calSettings = {}
 
         if self.paramGrpChkBx.isChecked():
+            pixel_size = self.pixsSpnBx.value()
+            if pixel_size <= 0:
+                pixel_size, ok = QInputDialog.getDouble(
+                    self,
+                    "Pixel Size Required",
+                    "Detector pixel size was not identified. Enter pixel size in mm:",
+                    0.0,
+                    0.00001,
+                    5.0,
+                    8,
+                )
+                if not ok:
+                    return False
+                self.pixsSpnBx.setValue(pixel_size)
+                self.pixel_size_user_confirmed = True
+                self.pixel_size_source = "manual"
+
             self.calSettings = {
                 "lambda": self.lambdaSpnBx.value(),
-                "pixel_size": self.pixsSpnBx.value(),
+                "pixel_size": pixel_size,
                 "sdd": self.sddSpnBx.value(),
                 "scale": (self.lambdaSpnBx.value() * self.sddSpnBx.value())
-                / self.pixsSpnBx.value(),
+                / pixel_size,
                 "type": "cont",
             }
+            if self.pixel_size_source:
+                self.calSettings["pixel_size_source"] = self.pixel_size_source
         elif self.calImageGrpChkBox.isChecked():
             self.calSettings["silverB"] = self.silverBehenate.value()
             self.calSettings["type"] = "img"
@@ -754,6 +792,11 @@ class CalibrationSettings(QDialog):
 
         if self.manDetector.isChecked():
             self.calSettings["detector"] = self.detectorChoice.currentText()
+        elif self.detector_metadata.get("name"):
+            self.calSettings["detector"] = self.detector_metadata["name"]
+
+        if self.detector_metadata:
+            self.calSettings["detector_metadata"] = self.detector_metadata
 
         cache = {
             "path": self.pathText.text(),
@@ -761,6 +804,149 @@ class CalibrationSettings(QDialog):
             "version": self.version,
         }
         self._settings_manager.save_calibration_cache(cache)
+        return True
+
+    @staticmethod
+    def _normalized_detector_name(name):
+        return "".join(ch.lower() for ch in str(name) if ch.isalnum())
+
+    def _match_detector_name(self, raw_name):
+        if raw_name is None:
+            return None
+        raw_norm = self._normalized_detector_name(raw_name)
+        if not raw_norm:
+            return None
+        for detector_name in Detector.registry.keys():
+            det_norm = self._normalized_detector_name(detector_name)
+            if raw_norm == det_norm or raw_norm in det_norm or det_norm in raw_norm:
+                return detector_name
+        return None
+
+    def _detector_from_shape(self, img_shape):
+        for detector_name, detector_cls in Detector.registry.items():
+            max_shape = getattr(detector_cls, "MAX_SHAPE", None)
+            if max_shape == img_shape or max_shape == tuple(reversed(img_shape)):
+                return detector_name
+        return None
+
+    def _detector_from_fabio(self, fabio_img, img_shape):
+        candidates = []
+        for attr in ("detector", "detector_name", "instrument"):
+            if hasattr(fabio_img, attr):
+                candidates.append(getattr(fabio_img, attr))
+
+        header = getattr(fabio_img, "header", {}) or {}
+        for key in (
+            "Detector",
+            "detector",
+            "Detector_name",
+            "detector_name",
+            "DETECTOR",
+            "INSTRUMENT",
+            "instrument",
+        ):
+            if key in header:
+                candidates.append(header[key])
+
+        for candidate in candidates:
+            detector_name = self._match_detector_name(candidate)
+            if detector_name:
+                return detector_name, "fabio metadata"
+
+        detector_name = self._detector_from_shape(img_shape)
+        if detector_name:
+            return detector_name, "image shape"
+        return None, None
+
+    def _detector_pixel_size_mm(self, detector_name):
+        try:
+            detector = detector_factory(detector_name)
+        except Exception:
+            return None
+
+        pixel1 = getattr(detector, "pixel1", None)
+        pixel2 = getattr(detector, "pixel2", None)
+        pixels = [p for p in (pixel1, pixel2) if p]
+        if not pixels:
+            return None
+        return float(np.mean(pixels) * 1000.0)
+
+    @staticmethod
+    def _float_from_header_value(value):
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        text = str(value).strip().replace(",", " ")
+        for part in text.split():
+            try:
+                return float(part)
+            except ValueError:
+                continue
+        return None
+
+    def _header_pixel_size_mm(self, fabio_img):
+        header = getattr(fabio_img, "header", {}) or {}
+        pixel_keys = (
+            (("PixelSize_mm", "pixel_size_mm", "XPixelSize_mm", "YPixelSize_mm"), 1.0),
+            (
+                ("PixelSize_um", "pixel_size_um", "XPixelSize_um", "YPixelSize_um"),
+                0.001,
+            ),
+            (("PSize_1", "PSize_2", "PixelSize_m", "pixel_size_m"), 1000.0),
+        )
+        values = []
+        for keys, multiplier in pixel_keys:
+            for key in keys:
+                if key in header:
+                    value = self._float_from_header_value(header[key])
+                    if value:
+                        values.append(value * multiplier)
+        if values:
+            return float(np.mean(values))
+        return None
+
+    def _apply_detector_metadata(self, fabio_img, img):
+        detector_name, source = self._detector_from_fabio(fabio_img, img.shape)
+        header_pixel_size = self._header_pixel_size_mm(fabio_img)
+        if not detector_name:
+            if header_pixel_size and not self.pixel_size_user_confirmed:
+                self.pixsSpnBx.setValue(header_pixel_size)
+                self.pixel_size_source = "fabio header"
+                self.detector_metadata = {
+                    "source": "fabio header",
+                    "pixel_size": header_pixel_size,
+                    "pixel_size_unit": "mm",
+                }
+            return
+
+        pixel_size = self._detector_pixel_size_mm(detector_name)
+        self.detector_metadata = {
+            "name": detector_name,
+            "source": source,
+        }
+        if header_pixel_size:
+            self.detector_metadata["header_pixel_size"] = header_pixel_size
+            self.detector_metadata["header_pixel_size_unit"] = "mm"
+        if pixel_size:
+            self.detector_metadata["pixel_size"] = pixel_size
+            self.detector_metadata["pixel_size_unit"] = "mm"
+            if not self.pixel_size_user_confirmed:
+                self.pixsSpnBx.setValue(pixel_size)
+                self.pixel_size_source = f"detector:{detector_name}"
+        elif header_pixel_size and not self.pixel_size_user_confirmed:
+            self.detector_metadata["pixel_size"] = header_pixel_size
+            self.detector_metadata["pixel_size_unit"] = "mm"
+            self.pixsSpnBx.setValue(header_pixel_size)
+            self.pixel_size_source = "fabio header"
+
+        if (
+            detector_name in self.alldetectorChoices
+            and not self.manDetector.isChecked()
+        ):
+            self.detectorChoice.setCurrentIndex(
+                self.alldetectorChoices.index(detector_name)
+            )
 
     def refine_point_on_ring(self, img, center, user_point, search_radius=20):
         """
@@ -863,8 +1049,10 @@ class CalibrationSettings(QDialog):
         Get the image and returns a copy of the calibration image and the image displayed.
         """
         if self.cal_img is None:
-            self.cal_img = fabio.open(str(self.calFile)).data
+            self.cal_fabio_img = fabio.open(str(self.calFile))
+            self.cal_img = self.cal_fabio_img.data
             self.cal_img = ifHdfReadConvertless(str(self.calFile), self.cal_img)
+            self._apply_detector_metadata(self.cal_fabio_img, self.cal_img)
 
         if self.minInt.value() == 0 and self.maxInt.value() == 0:
             self.uiUpdating = True
@@ -1118,7 +1306,11 @@ class CalibrationSettings(QDialog):
         """
         React to the Manual Select Detector checkbox.
         """
-        if not self.manDetector.isChecked() and "detector" in self.calSettings:
+        if (
+            self.calSettings
+            and not self.manDetector.isChecked()
+            and "detector" in self.calSettings
+        ):
             self.calSettings.pop("detector")
         self.detectorChoice.setEnabled(self.manDetector.isChecked())
 
@@ -1138,7 +1330,8 @@ class CalibrationSettings(QDialog):
         """
         React to the OK button.
         """
-        self.saveSettings()
+        if not self.saveSettings():
+            return
         print(self.calSettings)
         self.accept()
 

--- a/musclex/CalibrationSettings/CalibrationSettings.py
+++ b/musclex/CalibrationSettings/CalibrationSettings.py
@@ -422,6 +422,8 @@ class CalibrationSettings(QDialog):
         if name == "pixS" and obj.value() > 0:
             self.pixel_size_user_confirmed = True
             self.pixel_size_source = "manual"
+        elif name == "detector" and self.manDetector.isChecked():
+            self._apply_manual_detector_metadata()
         self.log_changes(name, obj)
 
     def decalibrate(self):
@@ -871,6 +873,55 @@ class CalibrationSettings(QDialog):
             return None
         return float(np.mean(pixels) * 1000.0)
 
+    def _detector_metadata_from_name(self, detector_name, source):
+        try:
+            detector_cls = Detector.registry.get(detector_name)
+            detector = detector_factory(detector_name)
+        except Exception:
+            detector_cls = None
+            detector = None
+
+        metadata = {
+            "name": detector_name,
+            "source": source,
+        }
+        max_shape = getattr(detector_cls, "MAX_SHAPE", None)
+        if max_shape is not None:
+            metadata["max_shape"] = tuple(max_shape)
+
+        if detector is not None:
+            pixel1 = getattr(detector, "pixel1", None)
+            pixel2 = getattr(detector, "pixel2", None)
+            if pixel1:
+                metadata["pixel1_m"] = float(pixel1)
+            if pixel2:
+                metadata["pixel2_m"] = float(pixel2)
+
+        pixel_size = self._detector_pixel_size_mm(detector_name)
+        if pixel_size:
+            metadata["pixel_size"] = pixel_size
+            metadata["pixel_size_unit"] = "mm"
+        return metadata
+
+    def _apply_manual_detector_metadata(self):
+        detector_name = self.detectorChoice.currentText()
+        if not detector_name:
+            return
+
+        self.detector_metadata = self._detector_metadata_from_name(
+            detector_name, "manual"
+        )
+        pixel_size = self.detector_metadata.get("pixel_size")
+        if pixel_size:
+            self.pixsSpnBx.setValue(pixel_size)
+            self.pixel_size_user_confirmed = True
+            self.pixel_size_source = f"manual detector:{detector_name}"
+
+        if self.calSettings is None:
+            self.calSettings = {}
+        self.calSettings["detector"] = detector_name
+        self.calSettings["detector_metadata"] = self.detector_metadata
+
     @staticmethod
     def _float_from_header_value(value):
         if value is None:
@@ -1313,6 +1364,8 @@ class CalibrationSettings(QDialog):
         ):
             self.calSettings.pop("detector")
         self.detectorChoice.setEnabled(self.manDetector.isChecked())
+        if self.manDetector.isChecked():
+            self._apply_manual_detector_metadata()
 
     def correctMisSetting(self):
         """

--- a/musclex/CalibrationSettings/CalibrationSettings.py
+++ b/musclex/CalibrationSettings/CalibrationSettings.py
@@ -39,6 +39,38 @@ from ..ui.pyqt_utils import *
 from ..utils.file_manager import fullPath, ifHdfReadConvertless
 from ..utils.image_processor import *
 
+CUSTOM_MAR_165_2X2 = "MAR_165_2x2"
+MAR_165_BASE_PIXEL_SIZE_MM = 0.079
+MAR_165_BASE_SHAPE = (2048, 2048)
+
+
+def _normalized_detector_name(name):
+    return "".join(ch.lower() for ch in str(name) if ch.isalnum())
+
+
+def _find_mar_165_base_detector_name(registry=None):
+    registry = Detector.registry if registry is None else registry
+    for detector_name in registry.keys():
+        normalized = _normalized_detector_name(detector_name)
+        if "mar" in normalized and "165" in normalized and "2x2" not in normalized:
+            return detector_name
+    return None
+
+
+def _detector_shape_from_registry(detector_name, registry=None):
+    registry = Detector.registry if registry is None else registry
+    detector_cls = registry.get(detector_name)
+    shape = getattr(detector_cls, "MAX_SHAPE", None)
+    if shape is None:
+        return None
+    return tuple(int(value) for value in shape)
+
+
+def _halved_shape(shape):
+    if not shape:
+        return None
+    return tuple(max(1, int(value) // 2) for value in shape)
+
 
 class CalibrationSettings(QDialog):
     """
@@ -46,6 +78,7 @@ class CalibrationSettings(QDialog):
     """
 
     KEV_NM = 1.239841984
+    CUSTOM_MAR_165_2X2 = CUSTOM_MAR_165_2X2
 
     def __init__(
         self,
@@ -283,6 +316,7 @@ class CalibrationSettings(QDialog):
 
         self.misSettingChkBx = QCheckBox("Correct Mis-Setting Angles")
         self.misSettingChkBx.setEnabled(False)
+        self.misSettingChkBx.setHidden(True)
         self.misSettingChkBx.setToolTip("Not yet implemented")
 
         if center is not None:
@@ -313,13 +347,23 @@ class CalibrationSettings(QDialog):
 
         self.manDetector = QCheckBox("Manually Select Detector")
         self.detectorChoice = QComboBox()
-        self.alldetectorChoices = list(Detector.registry.keys())
+        self.detectorChoice.setObjectName("detectorChoice")
+        self._register_custom_mar_165_2x2_detector()
+        self.alldetectorChoices = self._detector_choices()
         for c in self.alldetectorChoices:
             self.detectorChoice.addItem(c)
         if detector is not None:
-            self.detectorChoice.setCurrentIndex(self.alldetectorChoices.index(detector))
-            self.manDetector.setChecked(True)
-            self.detectorChoice.setEnabled(True)
+            matched_detector = self._match_detector_name(detector)
+            if matched_detector in self.alldetectorChoices:
+                self.detectorChoice.setCurrentIndex(
+                    self.alldetectorChoices.index(matched_detector)
+                )
+                self.manDetector.setChecked(True)
+                self.detectorChoice.setEnabled(True)
+            else:
+                self.detectorChoice.setCurrentIndex(0)
+                self.manDetector.setChecked(False)
+                self.detectorChoice.setEnabled(False)
         else:
             self.detectorChoice.setCurrentIndex(0)
             self.manDetector.setChecked(False)
@@ -338,6 +382,12 @@ class CalibrationSettings(QDialog):
         self.paramLayout.addWidget(QLabel("Pixel Size : "), 3, 0, 1, 1)
         self.paramLayout.addWidget(self.pixsSpnBx, 3, 1, 1, 1)
         self.paramLayout.addWidget(QLabel("mm"), 3, 2, 1, 1)
+        self.scaleComputedLabel = QLabel()
+        self.scaleComputedLabel.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.sddComputedLabel = QLabel()
+        self.sddComputedLabel.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self.paramLayout.addWidget(self.scaleComputedLabel, 4, 0, 1, 3)
+        self.paramLayout.addWidget(self.sddComputedLabel, 5, 0, 1, 3)
 
         self.mainLayout.addWidget(self.calImageGrpChkBox)
         self.mainLayout.addWidget(self.calImageGrp)
@@ -415,6 +465,13 @@ class CalibrationSettings(QDialog):
         self.detectorChoice.currentIndexChanged.connect(
             lambda: self.settingChanged("detector", self.detectorChoice)
         )
+        self.lambdaSpnBx.valueChanged.connect(self._update_computed_labels)
+        self.energySpnBx.valueChanged.connect(self._update_computed_labels)
+        self.sddSpnBx.valueChanged.connect(self._update_computed_labels)
+        self.pixsSpnBx.valueChanged.connect(self._update_computed_labels)
+        self.silverBehenate.valueChanged.connect(self._update_computed_labels)
+        self.detectorChoice.currentIndexChanged.connect(self._update_computed_labels)
+        self._update_computed_labels()
 
     def paramChecked(self):
         """
@@ -425,6 +482,7 @@ class CalibrationSettings(QDialog):
         self.calImageGrp.setEnabled(False)
 
         self.decalibrate()
+        self._update_computed_labels()
 
     def calImageChecked(self):
         """
@@ -434,6 +492,7 @@ class CalibrationSettings(QDialog):
         self.paramGrpChkBx.setChecked(False)
         self.paramGrp.setEnabled(False)
         self.decalibrate()
+        self._update_computed_labels()
 
     def settingChanged(self, name, obj):
         """
@@ -446,8 +505,10 @@ class CalibrationSettings(QDialog):
         elif name == "pixS" and obj.value() > 0:
             self.pixel_size_user_confirmed = True
             self.pixel_size_source = "manual"
+            self._clear_manual_detector_selection()
         elif name == "detector" and self.manDetector.isChecked():
             self._apply_manual_detector_metadata()
+        self._update_computed_labels()
         self.log_changes(name, obj)
 
     @classmethod
@@ -471,6 +532,83 @@ class CalibrationSettings(QDialog):
         wavelength = self.wavelength_from_energy(self.energySpnBx.value())
         if wavelength > 0:
             self.lambdaSpnBx.setValue(wavelength)
+
+    def _clear_manual_detector_selection(self):
+        self.detector_metadata = {}
+        if self.calSettings:
+            self.calSettings.pop("detector", None)
+            self.calSettings.pop("detector_metadata", None)
+
+        self.manDetector.blockSignals(True)
+        self.detectorChoice.blockSignals(True)
+        self.manDetector.setChecked(False)
+        self.detectorChoice.setEnabled(False)
+        self.detectorChoice.blockSignals(False)
+        self.manDetector.blockSignals(False)
+
+    def _calibration_image_scale(self):
+        if not self.calSettings or self.calSettings.get("type") != "img":
+            return None
+        radius = self.calSettings.get("radius")
+        if radius is None:
+            return None
+        return float(self.silverBehenate.value()) * float(radius)
+
+    def _parameter_scale(self):
+        pixel_size = float(self.pixsSpnBx.value())
+        if pixel_size <= 0:
+            return None
+        return (
+            float(self.lambdaSpnBx.value()) * float(self.sddSpnBx.value()) / pixel_size
+        )
+
+    def _current_scale(self):
+        image_scale = self._calibration_image_scale()
+        if image_scale is not None:
+            return image_scale
+        return self._parameter_scale()
+
+    def _inferred_sdd_from_scale(self, scale=None):
+        pixel_size = float(self.pixsSpnBx.value())
+        wavelength = float(self.lambdaSpnBx.value())
+        if pixel_size <= 0 or wavelength <= 0:
+            return None
+        if scale is None:
+            scale = self._current_scale()
+        if scale is None:
+            return None
+        return float(scale) * pixel_size / wavelength
+
+    def _update_computed_labels(self, *args):
+        if not hasattr(self, "scaleComputedLabel"):
+            return
+
+        scale = self._current_scale()
+        if scale is None:
+            scale_text = "scale = silverB * radius: unavailable"
+        else:
+            scale_text = f"scale = silverB * radius: {scale:.8g}"
+
+        inferred_sdd = self._inferred_sdd_from_scale(scale)
+        if inferred_sdd is None:
+            sdd_text = "Sdd = scale * pixel_size / lambda: unavailable"
+        else:
+            sdd_text = f"Sdd = scale * pixel_size / lambda: {inferred_sdd:.8g} mm"
+
+        self.scaleComputedLabel.setText(scale_text)
+        self.sddComputedLabel.setText(sdd_text)
+
+    def _sync_parameters_from_calibration_image(self):
+        scale = self._calibration_image_scale()
+        if scale is None:
+            self._update_computed_labels()
+            return
+
+        self.calSettings["scale"] = scale
+        inferred_sdd = self._inferred_sdd_from_scale(scale)
+        if inferred_sdd is not None:
+            self.sddSpnBx.setValue(inferred_sdd)
+        self._update_computed_labels()
 
     def decalibrate(self):
         """
@@ -533,13 +671,15 @@ class CalibrationSettings(QDialog):
                                 round(cal_results["center"][1], 4),
                             ],
                             "radius": round(cal_results["radius"], 4),
-                            "scale": round(cal_results["scale"], 4),
+                            "scale": cal_results["silver_behenate"]
+                            * round(cal_results["radius"], 4),
                             "silverB": cal_results["silver_behenate"],
                             "type": "img",
                         }
 
                         # Update silver behenate value
                         self.silverBehenate.setValue(cal_results["silver_behenate"])
+                        self._sync_parameters_from_calibration_image()
 
                         print(
                             f"Manual calibration completed with {len(cal_results['selected_points'])} points"
@@ -763,7 +903,7 @@ class CalibrationSettings(QDialog):
             self.centerX.setValue(settings["center"][0])
             self.centerY.setValue(settings["center"][1])
 
-        detector = settings.get("detector")
+        detector = self._match_detector_name(settings.get("detector"))
         if detector in self.alldetectorChoices:
             self.detectorChoice.setCurrentIndex(self.alldetectorChoices.index(detector))
             self.manDetector.setChecked(True)
@@ -783,9 +923,11 @@ class CalibrationSettings(QDialog):
             self.minInt.setHidden(True)
             self.maxIntLabel.setHidden(True)
             self.maxInt.setHidden(True)
+            self._update_computed_labels()
             return True
 
         self.updateImage()
+        self._update_computed_labels()
         QMessageBox.information(
             self,
             "Load Calibration",
@@ -841,6 +983,11 @@ class CalibrationSettings(QDialog):
         elif self.calImageGrpChkBox.isChecked():
             self.calSettings["silverB"] = self.silverBehenate.value()
             self.calSettings["type"] = "img"
+            if "radius" in self.calSettings:
+                self.calSettings["scale"] = (
+                    self.silverBehenate.value() * self.calSettings["radius"]
+                )
+                self._sync_parameters_from_calibration_image()
 
         if not self.quadrant_folded:
             self.calSettings["center"] = [self.centerX.value(), self.centerY.value()]
@@ -863,7 +1010,57 @@ class CalibrationSettings(QDialog):
 
     @staticmethod
     def _normalized_detector_name(name):
-        return "".join(ch.lower() for ch in str(name) if ch.isalnum())
+        return _normalized_detector_name(name)
+
+    @classmethod
+    def _detector_choices(cls):
+        cls._register_custom_mar_165_2x2_detector()
+        return sorted(Detector.registry.keys(), key=str.casefold)
+
+    @classmethod
+    def _custom_mar_165_2x2_metadata(cls):
+        base_name = _find_mar_165_base_detector_name()
+        base_pixel_size = None
+        base_shape = None
+        if base_name:
+            try:
+                base_detector = detector_factory(base_name)
+                pixel1 = getattr(base_detector, "pixel1", None)
+                pixel2 = getattr(base_detector, "pixel2", None)
+                pixels = [p for p in (pixel1, pixel2) if p]
+                if pixels:
+                    base_pixel_size = float(np.mean(pixels) * 1000.0)
+            except Exception:
+                base_pixel_size = None
+            base_shape = _detector_shape_from_registry(base_name)
+
+        if base_pixel_size is None:
+            base_pixel_size = MAR_165_BASE_PIXEL_SIZE_MM
+        if base_shape is None:
+            base_shape = MAR_165_BASE_SHAPE
+
+        pixel_size = float(base_pixel_size) * 2.0
+        shape = _halved_shape(base_shape)
+        return base_name, pixel_size, shape
+
+    @classmethod
+    def _register_custom_mar_165_2x2_detector(cls):
+        if CUSTOM_MAR_165_2X2 in Detector.registry:
+            return
+
+        _, pixel_size_mm, shape = cls._custom_mar_165_2x2_metadata()
+        pixel_size_m = pixel_size_mm / 1000.0
+
+        attrs = {
+            "pixel1": pixel_size_m,
+            "pixel2": pixel_size_m,
+            "aliases": [CUSTOM_MAR_165_2X2],
+        }
+        if shape:
+            attrs["MAX_SHAPE"] = tuple(shape)
+
+        custom_detector = type(CUSTOM_MAR_165_2X2, (Detector,), attrs)
+        Detector.registry[CUSTOM_MAR_165_2X2] = custom_detector
 
     def _match_detector_name(self, raw_name):
         if raw_name is None:
@@ -914,6 +1111,10 @@ class CalibrationSettings(QDialog):
         return None, None
 
     def _detector_pixel_size_mm(self, detector_name):
+        if detector_name == CUSTOM_MAR_165_2X2:
+            _, pixel_size, _ = self._custom_mar_165_2x2_metadata()
+            return pixel_size
+
         try:
             detector = detector_factory(detector_name)
         except Exception:
@@ -927,6 +1128,22 @@ class CalibrationSettings(QDialog):
         return float(np.mean(pixels) * 1000.0)
 
     def _detector_metadata_from_name(self, detector_name, source):
+        if detector_name == CUSTOM_MAR_165_2X2:
+            base_name, pixel_size, shape = self._custom_mar_165_2x2_metadata()
+            metadata = {
+                "name": detector_name,
+                "source": source,
+                "pixel_size": pixel_size,
+                "pixel_size_unit": "mm",
+                "pixel1_m": pixel_size / 1000.0,
+                "pixel2_m": pixel_size / 1000.0,
+            }
+            if base_name:
+                metadata["base_detector"] = base_name
+            if shape:
+                metadata["max_shape"] = tuple(shape)
+            return metadata
+
         try:
             detector_cls = Detector.registry.get(detector_name)
             detector = detector_factory(detector_name)
@@ -1215,6 +1432,8 @@ class CalibrationSettings(QDialog):
                 "radius": round((final_radius[0] + final_radius[1]) / 4.0),
                 "scale": round((final_radius[0] + final_radius[1]) / 4.0)
                 * self.silverBehenate.value(),
+                "silverB": self.silverBehenate.value(),
+                "type": "img",
             }
 
             # Optional: Visualize refined points on the image
@@ -1295,8 +1514,11 @@ class CalibrationSettings(QDialog):
                 "center": [fixcenter[0], fixcenter[1]],
                 "radius": cali_radius,
                 "scale": cali_radius * self.silverBehenate.value(),
+                "silverB": self.silverBehenate.value(),
+                "type": "img",
             }
 
+        self._sync_parameters_from_calibration_image()
         self.updateImage()
 
     def updateImage(self):
@@ -1390,6 +1612,7 @@ class CalibrationSettings(QDialog):
         else:
             self.resize(500, 1)
             self.calImgCanvas.setHidden(True)
+        self._update_computed_labels()
 
     def centerFixed(self):
         """
@@ -1416,6 +1639,13 @@ class CalibrationSettings(QDialog):
             and "detector" in self.calSettings
         ):
             self.calSettings.pop("detector")
+        if (
+            not self.manDetector.isChecked()
+            and self.detector_metadata.get("source") == "manual"
+        ):
+            self.detector_metadata = {}
+            if self.calSettings:
+                self.calSettings.pop("detector_metadata", None)
         self.detectorChoice.setEnabled(self.manDetector.isChecked())
         if self.manDetector.isChecked():
             self._apply_manual_detector_metadata()

--- a/musclex/algorithms/calibration_refinement/__init__.py
+++ b/musclex/algorithms/calibration_refinement/__init__.py
@@ -1,0 +1,10 @@
+"""Calibration refinement helpers for MuscleX GUI integration.
+
+Use :mod:`musclex.algorithms.calibration_refinement.adapter` for the callable
+GUI-facing API. The ``refine_center`` name is reserved for the center
+refinement package directory.
+"""
+
+from . import adapter
+
+__all__ = ["adapter"]

--- a/musclex/algorithms/calibration_refinement/adapter.py
+++ b/musclex/algorithms/calibration_refinement/adapter.py
@@ -1,0 +1,221 @@
+"""Small callable facade for calibration refinement algorithms.
+
+The copied refinement scripts are intentionally algorithm-heavy and expose
+several lower-level functions. This module keeps GUI callers on a compact API.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Iterable, Sequence
+
+import numpy as np
+
+CENTER_METHOD_REGISTRATION = "registration"
+CENTER_METHOD_GRADIENT = "gradient"
+CENTER_METHOD_SEARCH = "search"
+
+CENTER_SEARCH_LEVELS = "4:1:2:0.5,1:0.25:0.5:0.1,0.25:0.05:0.1:0.02"
+ROTATION_SEARCH_LEVELS = "2:0.5,0.5:0.1,0.1:0.02"
+LOCAL_SEARCH_RADIUS = 200
+
+
+def _normalise_image(image: np.ndarray) -> np.ndarray:
+    arr = np.asarray(image, dtype=np.float64)
+    if arr.ndim != 2:
+        raise ValueError("Calibration refinement requires a 2D image.")
+    return arr
+
+
+def _normalise_mask(mask, shape) -> np.ndarray:
+    if mask is None:
+        return np.zeros(shape, dtype=np.uint8)
+    arr = np.asarray(mask)
+    if arr.shape != shape:
+        raise ValueError(
+            f"Calibration refinement mask shape {arr.shape} does not match image shape {shape}."
+        )
+    return (arr != 0).astype(np.uint8)
+
+
+def _normalise_center(center) -> tuple[float, float]:
+    if center is None or len(center) != 2:
+        raise ValueError("Calibration refinement requires an initial center.")
+    return float(center[0]), float(center[1])
+
+
+def _normalise_rotation(rotation) -> float:
+    return float(rotation if rotation is not None else 0.0)
+
+
+def _ordered_center_methods(methods: Iterable[str]) -> list[str]:
+    selected = {str(method).lower() for method in methods}
+    if CENTER_METHOD_SEARCH in selected:
+        selected.update({CENTER_METHOD_REGISTRATION, CENTER_METHOD_GRADIENT})
+    if CENTER_METHOD_GRADIENT in selected:
+        selected.add(CENTER_METHOD_REGISTRATION)
+    ordered = []
+    for method in (
+        CENTER_METHOD_REGISTRATION,
+        CENTER_METHOD_GRADIENT,
+        CENTER_METHOD_SEARCH,
+    ):
+        if method in selected:
+            ordered.append(method)
+    if not ordered:
+        raise ValueError("Select at least one center refinement method.")
+    return ordered
+
+
+def _grid_for(image: np.ndarray, module, radius_x=None, radius_y=None):
+    h, w = image.shape
+    return module.make_canonical_grid(
+        w,
+        h,
+        radius_x=radius_x,
+        radius_y=radius_y,
+    )
+
+
+def refine_center(
+    image: np.ndarray,
+    mask,
+    center: Sequence[float],
+    rotation,
+    methods: Iterable[str],
+) -> dict:
+    """Run the selected center refinement pipeline.
+
+    Returns a dict with ``center``, ``rotation``, ``loss``, and per-stage results.
+    The returned rotation is for diagnostics; GUI callers may choose not to save it.
+    """
+    image = _normalise_image(image)
+    mask = _normalise_mask(mask, image.shape)
+    current_center = _normalise_center(center)
+    current_rotation = _normalise_rotation(rotation)
+
+    stages = []
+    for method in _ordered_center_methods(methods):
+        if method == CENTER_METHOD_REGISTRATION:
+            reg = import_module(
+                "musclex.algorithms.calibration_refinement.refine_center.registration_refinement"
+            )
+
+            UX, UY = _grid_for(image, reg)
+            result = reg.run_ecc_refinement(
+                image=image,
+                mask=mask,
+                init_center=current_center,
+                init_angle_deg=current_rotation,
+                UX=UX,
+                UY=UY,
+                passes=20,
+                min_valid_fold=2,
+                min_valid_registration=100,
+                ecc_iterations=200,
+                ecc_eps=1e-5,
+                ecc_blur_sigma=1.0,
+                w_trans=1.0,
+                w_angle=1.0,
+                max_center_step=2.0,
+                max_angle_step=1.0,
+                loss_mode="fold_std_norm",
+                erosion_px=3,
+                erode_mask=True,
+                reseed=True,
+                dynamic_ref=True,
+                verbose=False,
+            )
+            current_center = tuple(result["best_center"])
+            current_rotation = float(result["best_angle_deg"])
+
+        elif method == CENTER_METHOD_GRADIENT:
+            grad = import_module(
+                "musclex.algorithms.calibration_refinement.refine_center.gradient_refinement"
+            )
+
+            UX, UY = _grid_for(image, grad)
+            result = grad.optimize_symmetry_gradient(
+                image=image,
+                mask=mask,
+                init_center=current_center,
+                init_angle_deg=current_rotation,
+                UX=UX,
+                UY=UY,
+                max_center_step=1.0,
+                max_angle_step=0.5,
+                min_valid=2,
+                loss_mode="fold_std_norm",
+                maxiter=100,
+                verbose=False,
+            )
+            current_center = (result["center_x"], result["center_y"])
+            current_rotation = float(result["angle_deg"])
+
+        elif method == CENTER_METHOD_SEARCH:
+            search = import_module(
+                "musclex.algorithms.calibration_refinement.refine_center.search_refinement"
+            )
+
+            UX, UY = _grid_for(
+                image,
+                search,
+                radius_x=max(1, min(LOCAL_SEARCH_RADIUS, image.shape[1] // 2)),
+                radius_y=max(1, min(LOCAL_SEARCH_RADIUS, image.shape[0] // 2)),
+            )
+            result = search.coarse_to_fine_search(
+                image=image,
+                mask=mask,
+                init_center=current_center,
+                init_angle_deg=current_rotation,
+                UX=UX,
+                UY=UY,
+                levels=search.parse_levels(CENTER_SEARCH_LEVELS),
+                min_valid=2,
+                loss_mode="fold_std_norm",
+                verbose=False,
+            )
+            current_center = (result["center_x"], result["center_y"])
+            current_rotation = float(result["angle_deg"])
+
+        stages.append({"method": method, "result": result})
+
+    final = stages[-1]["result"]
+    return {
+        "center": (float(current_center[0]), float(current_center[1])),
+        "rotation": float(current_rotation),
+        "loss": final.get("best_loss", final.get("loss")),
+        "stages": stages,
+    }
+
+
+def refine_rotation(image: np.ndarray, mask, center: Sequence[float], rotation) -> dict:
+    """Run angle-only local search with the center fixed."""
+    rotation_search = import_module(
+        "musclex.algorithms.calibration_refinement.refine_rotation"
+    )
+
+    image = _normalise_image(image)
+    mask = _normalise_mask(mask, image.shape)
+    fixed_center = _normalise_center(center)
+    current_rotation = _normalise_rotation(rotation)
+
+    UX, UY = _grid_for(image, rotation_search)
+    result = rotation_search.coarse_to_fine_search(
+        image=image,
+        mask=mask,
+        init_center=fixed_center,
+        init_angle_deg=current_rotation,
+        UX=UX,
+        UY=UY,
+        levels=rotation_search.parse_angle_only_levels(ROTATION_SEARCH_LEVELS),
+        min_valid=2,
+        loss_mode="fold_std_norm",
+        verbose=False,
+    )
+    return {
+        "center": fixed_center,
+        "rotation": float(result["angle_deg"]),
+        "loss": result.get("loss"),
+        "result": result,
+    }

--- a/musclex/algorithms/calibration_refinement/refine_center/__init__.py
+++ b/musclex/algorithms/calibration_refinement/refine_center/__init__.py
@@ -1,0 +1,1 @@
+"""Center refinement algorithm implementations."""

--- a/musclex/algorithms/calibration_refinement/refine_center/gradient_refinement.py
+++ b/musclex/algorithms/calibration_refinement/refine_center/gradient_refinement.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""Serial gradient-based symmetry refinement for MuscleX calibration refinement."""
+
+from __future__ import annotations
+
+import math
+import time
+import cv2
+import numpy as np
+from scipy.optimize import minimize
+
+try:
+    from musclex.utils.fold_symmetry import _compute_fold_symmetry
+except Exception:
+    from utils import _compute_fold_symmetry
+
+# Sampling
+# ------------------------------------------------------------
+
+
+def bilinear_sample(image: np.ndarray, x: np.ndarray, y: np.ndarray, fill_value=0.0):
+    h, w = image.shape
+
+    x0 = np.floor(x).astype(np.int64)
+    y0 = np.floor(y).astype(np.int64)
+    x1 = x0 + 1
+    y1 = y0 + 1
+
+    valid = (x0 >= 0) & (x1 < w) & (y0 >= 0) & (y1 < h)
+
+    x0c = np.clip(x0, 0, w - 1)
+    x1c = np.clip(x1, 0, w - 1)
+    y0c = np.clip(y0, 0, h - 1)
+    y1c = np.clip(y1, 0, h - 1)
+
+    Ia = image[y0c, x0c]
+    Ib = image[y0c, x1c]
+    Ic = image[y1c, x0c]
+    Id = image[y1c, x1c]
+
+    wa = (x1 - x) * (y1 - y)
+    wb = (x - x0) * (y1 - y)
+    wc = (x1 - x) * (y - y0)
+    wd = (x - x0) * (y - y0)
+
+    out = wa * Ia + wb * Ib + wc * Ic + wd * Id
+    out = np.where(valid, out, fill_value)
+
+    return out, valid
+
+
+def nearest_sample(mask: np.ndarray, x: np.ndarray, y: np.ndarray, fill_value=1):
+    h, w = mask.shape
+
+    xi = np.rint(x).astype(np.int64)
+    yi = np.rint(y).astype(np.int64)
+
+    valid = (xi >= 0) & (xi < w) & (yi >= 0) & (yi < h)
+
+    xic = np.clip(xi, 0, w - 1)
+    yic = np.clip(yi, 0, h - 1)
+
+    out = mask[yic, xic]
+    out = np.where(valid, out, fill_value)
+
+    return out.astype(np.uint8), valid
+
+
+# ------------------------------------------------------------
+# Geometry and folding
+# ------------------------------------------------------------
+
+QUADRANTS = [
+    ("++", +1, +1),
+    ("+-", +1, -1),
+    ("-+", -1, +1),
+    ("--", -1, -1),
+]
+
+
+def _image_with_mask_sentinel(image: np.ndarray, mask: np.ndarray) -> np.ndarray:
+    """Return *image* with masked-out pixels set to a sentinel ``_compute_fold_symmetry``
+    treats as invalid (``<= INVALID_PIXEL_THRESHOLD = -1``). When the mask has no
+    invalid pixels, the original array is returned without copying."""
+    if mask is None or not mask.any():
+        return image
+    out = image.astype(np.float64, copy=True)
+    out[mask != 0] = -1.0
+    return out
+
+
+def _local_fold_std_norm(folded, var, count, min_valid):
+    """Region-restricted analogue of ``_compute_fold_symmetry``'s ``fold_std_norm``.
+
+    Operates directly on the already-extracted quadrant stack (the
+    ``radius_x x radius_y`` folding grid) instead of warping/folding the whole
+    image, so the symmetry score is measured over exactly the region the
+    gradient optimization samples. Returns ``None`` when the foreground cannot
+    be determined reliably (mirrors the whole-image version).
+
+    ``folded`` is the per-pixel mean across valid quadrants (the "average
+    quadrant"), ``var`` the per-pixel population variance across valid
+    quadrants (ddof=0), and ``count`` the number of valid quadrant samples per
+    pixel.
+    """
+    keep = count >= max(2, min_valid)
+    if not np.any(keep):
+        return None
+
+    per_pixel_std = np.sqrt(np.maximum(var, 0.0))
+    fold_std_sum = float(np.sum(per_pixel_std[keep]))
+
+    # Foreground = diffraction signal in the averaged quadrant, separated from
+    # background with Otsu. Denominator = total foreground signal, making the
+    # score dimensionless / exposure-independent (same as the whole-image one).
+    finite_pos = folded[keep & (folded > 0)]
+    if finite_pos.size < 100:
+        return None
+
+    aq_min = float(finite_pos.min())
+    aq_max = float(finite_pos.max())
+    if aq_max <= aq_min:
+        return None
+
+    scaled = (folded - aq_min) / (aq_max - aq_min) * 255.0
+    scaled_u8 = np.nan_to_num(scaled, nan=0.0).clip(0, 255).astype(np.uint8)
+    thresh_scaled, _ = cv2.threshold(
+        scaled_u8, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU
+    )
+    threshold = aq_min + thresh_scaled / 255.0 * (aq_max - aq_min)
+
+    fg = (folded > threshold) & keep & (folded > 0)
+    if int(np.sum(fg)) < 100:
+        return None
+
+    total_fg_signal = float(np.sum(folded[fg]))
+    if total_fg_signal <= 0:
+        return None
+
+    return fold_std_sum / total_fg_signal
+
+
+def _whole_image_fold_std_norm(image, mask, center_x, center_y, angle_deg):
+    """Whole-image ``fold_std_norm`` score, ignoring ``radius_x``/``radius_y``.
+
+    Used only for the *reported* before/after loss (see ``main``): folding the
+    entire frame keeps those numbers comparable across runs with different
+    crop sizes and with the other refinement scripts, even though the
+    optimization itself is driven by the radius-restricted score from
+    ``_local_fold_std_norm``.
+    """
+    scores = _compute_fold_symmetry(
+        _image_with_mask_sentinel(image, mask),
+        (center_x, center_y),
+        angle_deg,
+    )
+    norm = scores.get("fold_std_norm")
+    return float(norm) if norm is not None else float("inf")
+
+
+def make_canonical_grid(width: int, height: int, radius_x=None, radius_y=None):
+    if radius_x is None:
+        radius_x = width // 2
+    if radius_y is None:
+        radius_y = height // 2
+
+    ux = np.arange(radius_x, dtype=np.float64)
+    uy = np.arange(radius_y, dtype=np.float64)
+    UY, UX = np.meshgrid(uy, ux, indexing="ij")
+    return UX, UY
+
+
+def quadrant_coordinates(UX, UY, center_x, center_y, angle_deg, sx, sy):
+    theta = math.radians(angle_deg)
+    cos_t = math.cos(theta)
+    sin_t = math.sin(theta)
+
+    x_rel = sx * UX
+    y_rel = sy * UY
+
+    x = center_x + cos_t * x_rel - sin_t * y_rel
+    y = center_y + sin_t * x_rel + cos_t * y_rel
+
+    return x, y
+
+
+def extract_quadrants(image, mask, center_x, center_y, angle_deg, UX, UY):
+    values = []
+    weights = []
+
+    for _, sx, sy in QUADRANTS:
+        x, y = quadrant_coordinates(
+            UX,
+            UY,
+            center_x=center_x,
+            center_y=center_y,
+            angle_deg=angle_deg,
+            sx=sx,
+            sy=sy,
+        )
+
+        v, in_bounds_img = bilinear_sample(image, x, y, fill_value=0.0)
+        m, in_bounds_mask = nearest_sample(mask, x, y, fill_value=1)
+
+        valid = in_bounds_img & in_bounds_mask & (m == 0)
+
+        values.append(v)
+        weights.append(valid.astype(np.float64))
+
+    return np.stack(values, axis=0), np.stack(weights, axis=0)
+
+
+def fold_and_loss(
+    image,
+    mask,
+    center_x,
+    center_y,
+    angle_deg,
+    UX,
+    UY,
+    min_valid=2,
+    robust=None,
+    huber_delta=0.02,
+    loss_mode: str = "var_mean",
+):
+    vals, weights = extract_quadrants(
+        image=image,
+        mask=mask,
+        center_x=center_x,
+        center_y=center_y,
+        angle_deg=angle_deg,
+        UX=UX,
+        UY=UY,
+    )
+
+    count = np.sum(weights, axis=0)
+    weighted_sum = np.sum(weights * vals, axis=0)
+
+    folded = np.zeros_like(weighted_sum)
+    valid_any = count > 0
+    folded[valid_any] = weighted_sum[valid_any] / count[valid_any]
+
+    diff2 = weights * (vals - folded[None, :, :]) ** 2
+
+    var = np.zeros_like(folded)
+    var[valid_any] = np.sum(diff2, axis=0)[valid_any] / count[valid_any]
+
+    valid_loss = count >= min_valid
+
+    if not np.any(valid_loss):
+        return folded, count, np.sqrt(np.maximum(var, 0.0)), float("inf")
+
+    if loss_mode == "fold_std_norm":
+        # Drive the optimization from the radius_x x radius_y folding region —
+        # the same quadrants sampled above — rather than warping/folding the
+        # whole image; see `_whole_image_fold_std_norm` for the whole-image
+        # score used for the final reported loss in `main`.
+        norm = _local_fold_std_norm(folded, var, count, min_valid)
+        loss = float(norm) if norm is not None else float("inf")
+
+    elif robust is None:
+        loss = float(np.mean(var[valid_loss]))
+
+    elif robust == "huber":
+        residual = np.sqrt(np.maximum(var[valid_loss], 0.0))
+        d = float(huber_delta)
+        abs_r = np.abs(residual)
+        penalty = np.where(
+            abs_r <= d,
+            0.5 * residual * residual,
+            d * (abs_r - 0.5 * d),
+        )
+        loss = float(np.mean(penalty))
+
+    else:
+        raise ValueError(f"Unknown robust option: {robust}")
+
+    residual_img = np.sqrt(np.maximum(var, 0.0))
+    return folded, count, residual_img, loss
+
+
+def transform_pattern_to_canonical(
+    image: np.ndarray,
+    mask: np.ndarray,
+    center_x: float,
+    center_y: float,
+    angle_deg: float,
+    fill_value: float = 0.0,
+) -> np.ndarray:
+    h, w = image.shape
+    cx_out = w / 2.0
+    cy_out = h / 2.0
+
+    y_out, x_out = np.mgrid[0:h, 0:w]
+    xo = x_out.astype(np.float64) - cx_out
+    yo = y_out.astype(np.float64) - cy_out
+
+    theta = math.radians(-angle_deg)
+    cos_t = math.cos(theta)
+    sin_t = math.sin(theta)
+
+    x_rel = cos_t * xo - sin_t * yo
+    y_rel = sin_t * xo + cos_t * yo
+
+    x_in = center_x + x_rel
+    y_in = center_y + y_rel
+
+    out, valid = bilinear_sample(image, x_in, y_in, fill_value=fill_value)
+    m, _ = nearest_sample(mask, x_in, y_in, fill_value=1)
+    out = np.where(valid & (m == 0), out, fill_value)
+    return out
+
+
+# ------------------------------------------------------------
+# Initialization
+# ------------------------------------------------------------
+
+
+def read_initial_estimate_from_report(path: str):
+    with open(path, "r", encoding="utf-8") as f:
+        report = json.load(f)
+
+    if "refined_estimate" not in report:
+        raise ValueError("init report does not contain refined_estimate")
+
+    refined = report["refined_estimate"]
+    center = refined.get("center_xy", None)
+    angle = refined.get("angle_degrees", None)
+
+    if center is None or angle is None:
+        raise ValueError("refined_estimate must contain center_xy and angle_degrees")
+
+    return [float(center[0]), float(center[1])], float(angle)
+
+
+# ------------------------------------------------------------
+# Optimization
+# ------------------------------------------------------------
+
+EVAL_FIELDNAMES = [
+    "eval_index",
+    "candidate_center_x",
+    "candidate_center_y",
+    "candidate_angle_deg",
+    "candidate_loss",
+    "candidate_objective",
+    "is_new_best",
+    "best_so_far_center_x",
+    "best_so_far_center_y",
+    "best_so_far_angle_deg",
+    "best_so_far_loss",
+    "best_so_far_objective",
+]
+
+
+def optimize_symmetry_gradient(
+    image,
+    mask,
+    init_center,
+    init_angle_deg,
+    UX,
+    UY,
+    max_center_step=2.0,
+    max_angle_step=1.0,
+    center_scale=1.0,
+    angle_scale=1.0,
+    min_valid=2,
+    robust=None,
+    huber_delta=0.02,
+    loss_mode: str = "var_mean",
+    reg_center=0.0,
+    reg_angle=0.0,
+    maxiter=100,
+    maxfun=500,
+    finite_diff_rel_step=None,
+    verbose=True,
+):
+    init_cx, init_cy = init_center
+
+    z_bounds = [
+        (-max_center_step / center_scale, +max_center_step / center_scale),
+        (-max_center_step / center_scale, +max_center_step / center_scale),
+        (-max_angle_step / angle_scale, +max_angle_step / angle_scale),
+    ]
+
+    rows = []
+    eval_counter = {"n": 0}
+
+    best = {
+        "z": np.array([0.0, 0.0, 0.0], dtype=np.float64),
+        "loss": float("inf"),
+        "objective": float("inf"),
+    }
+
+    def z_to_params(z):
+        cx = init_cx + center_scale * float(z[0])
+        cy = init_cy + center_scale * float(z[1])
+        angle = init_angle_deg + angle_scale * float(z[2])
+        return cx, cy, angle
+
+    def compute_objective(z):
+        cx, cy, angle = z_to_params(z)
+
+        _, _, _, loss = fold_and_loss(
+            image=image,
+            mask=mask,
+            center_x=cx,
+            center_y=cy,
+            angle_deg=angle,
+            UX=UX,
+            UY=UY,
+            min_valid=min_valid,
+            robust=robust,
+            huber_delta=huber_delta,
+            loss_mode=loss_mode,
+        )
+
+        dcx = cx - init_cx
+        dcy = cy - init_cy
+        dtheta = angle - init_angle_deg
+
+        objective = loss
+        objective += reg_center * (dcx * dcx + dcy * dcy)
+        objective += reg_angle * (dtheta * dtheta)
+
+        return float(objective), float(loss)
+
+    def objective_wrapper(z):
+        objective, loss = compute_objective(z)
+
+        eval_counter["n"] += 1
+
+        cx, cy, angle = z_to_params(z)
+
+        is_new_best = objective < best["objective"]
+
+        if is_new_best:
+            best["z"] = np.array(z, dtype=np.float64)
+            best["loss"] = loss
+            best["objective"] = objective
+
+        bx, by, bangle = z_to_params(best["z"])
+
+        rows.append(
+            {
+                "eval_index": eval_counter["n"],
+                "candidate_center_x": cx,
+                "candidate_center_y": cy,
+                "candidate_angle_deg": angle,
+                "candidate_loss": loss,
+                "candidate_objective": objective,
+                "is_new_best": int(is_new_best),
+                "best_so_far_center_x": bx,
+                "best_so_far_center_y": by,
+                "best_so_far_angle_deg": bangle,
+                "best_so_far_loss": best["loss"],
+                "best_so_far_objective": best["objective"],
+            }
+        )
+
+        return objective
+
+    t0 = time.perf_counter()
+
+    minimize_kwargs = {
+        "fun": objective_wrapper,
+        "x0": np.array([0.0, 0.0, 0.0], dtype=np.float64),
+        "method": "L-BFGS-B",
+        "bounds": z_bounds,
+        "jac": "2-point",
+        "options": {
+            "maxiter": int(maxiter),
+            "maxfun": int(maxfun),
+            "ftol": 1e-12,
+            "gtol": 1e-8,
+            "disp": False,
+        },
+    }
+
+    if finite_diff_rel_step is not None:
+        minimize_kwargs["options"]["finite_diff_rel_step"] = finite_diff_rel_step
+
+    result = minimize(**minimize_kwargs)
+
+    runtime = time.perf_counter() - t0
+
+    final_z = best["z"]
+    final_cx, final_cy, final_angle = z_to_params(final_z)
+    final_objective, final_loss = compute_objective(final_z)
+
+    if verbose:
+        print("Gradient optimization:")
+        print(f"  success: {result.success}")
+        print(f"  message: {result.message}")
+        print(f"  evaluations: {eval_counter['n']}")
+        print(f"  best loss: {final_loss:.8g}")
+        print(f"  best objective: {final_objective:.8g}")
+        print(f"  best center: ({final_cx:.6f}, {final_cy:.6f})")
+        print(f"  best angle: {final_angle:.6f}")
+
+    return {
+        "center_x": float(final_cx),
+        "center_y": float(final_cy),
+        "angle_deg": float(final_angle),
+        "loss": float(final_loss),
+        "objective": float(final_objective),
+        "rows": rows,
+        "runtime_seconds": runtime,
+        "optimizer_result": {
+            "success": bool(result.success),
+            "status": int(result.status),
+            "message": str(result.message),
+            "nit": int(result.nit),
+            "nfev": int(result.nfev),
+            "fun": float(result.fun),
+            "x_scaled": [float(v) for v in result.x],
+            "best_x_scaled": [float(v) for v in final_z],
+        },
+    }

--- a/musclex/algorithms/calibration_refinement/refine_center/registration_refinement.py
+++ b/musclex/algorithms/calibration_refinement/refine_center/registration_refinement.py
@@ -1,0 +1,1358 @@
+#!/usr/bin/env python3
+"""Serial ECC registration refinement for MuscleX calibration refinement."""
+
+from __future__ import annotations
+
+import math
+import time
+import cv2
+import matplotlib.pyplot as plt
+import numpy as np
+
+try:
+    from musclex.utils.fold_symmetry import _compute_fold_symmetry
+except Exception:
+    from utils import _compute_fold_symmetry
+
+try:
+    from scipy.optimize import least_squares
+
+    SCIPY_AVAILABLE = True
+except Exception:
+    SCIPY_AVAILABLE = False
+
+# Sampling
+# ------------------------------------------------------------
+
+
+def bilinear_sample(image: np.ndarray, x: np.ndarray, y: np.ndarray, fill_value=0.0):
+    h, w = image.shape
+
+    x0 = np.floor(x).astype(np.int64)
+    y0 = np.floor(y).astype(np.int64)
+    x1 = x0 + 1
+    y1 = y0 + 1
+
+    valid = (x0 >= 0) & (x1 < w) & (y0 >= 0) & (y1 < h)
+
+    x0c = np.clip(x0, 0, w - 1)
+    x1c = np.clip(x1, 0, w - 1)
+    y0c = np.clip(y0, 0, h - 1)
+    y1c = np.clip(y1, 0, h - 1)
+
+    Ia = image[y0c, x0c]
+    Ib = image[y0c, x1c]
+    Ic = image[y1c, x0c]
+    Id = image[y1c, x1c]
+
+    wa = (x1 - x) * (y1 - y)
+    wb = (x - x0) * (y1 - y)
+    wc = (x1 - x) * (y - y0)
+    wd = (x - x0) * (y - y0)
+
+    out = wa * Ia + wb * Ib + wc * Ic + wd * Id
+    out = np.where(valid, out, fill_value)
+
+    return out, valid
+
+
+def nearest_sample(mask: np.ndarray, x: np.ndarray, y: np.ndarray, fill_value=1):
+    h, w = mask.shape
+
+    xi = np.rint(x).astype(np.int64)
+    yi = np.rint(y).astype(np.int64)
+
+    valid = (xi >= 0) & (xi < w) & (yi >= 0) & (yi < h)
+
+    xic = np.clip(xi, 0, w - 1)
+    yic = np.clip(yi, 0, h - 1)
+
+    out = mask[yic, xic]
+    out = np.where(valid, out, fill_value)
+
+    return out.astype(np.uint8), valid
+
+
+# ------------------------------------------------------------
+# Geometry and folding
+# ------------------------------------------------------------
+
+QUADRANTS = [
+    ("++", +1, +1),
+    ("+-", +1, -1),
+    ("-+", -1, +1),
+    ("--", -1, -1),
+]
+
+
+def _image_with_mask_sentinel(image: np.ndarray, mask: np.ndarray) -> np.ndarray:
+    """Return *image* with masked-out pixels set to a sentinel ``_compute_fold_symmetry``
+    treats as invalid (``<= INVALID_PIXEL_THRESHOLD = -1``). When the mask has no
+    invalid pixels, the original array is returned without copying."""
+    if mask is None or not mask.any():
+        return image
+    out = image.astype(np.float64, copy=True)
+    out[mask != 0] = -1.0
+    return out
+
+
+def make_canonical_grid(width: int, height: int, radius_x=None, radius_y=None):
+    if radius_x is None:
+        radius_x = width // 2
+    if radius_y is None:
+        radius_y = height // 2
+
+    ux = np.arange(radius_x, dtype=np.float64)
+    uy = np.arange(radius_y, dtype=np.float64)
+    UY, UX = np.meshgrid(uy, ux, indexing="ij")
+    return UX, UY
+
+
+def quadrant_coordinates(UX, UY, center_x, center_y, angle_deg, sx, sy):
+    theta = math.radians(angle_deg)
+    cos_t = math.cos(theta)
+    sin_t = math.sin(theta)
+
+    x_rel = sx * UX
+    y_rel = sy * UY
+
+    x = center_x + cos_t * x_rel - sin_t * y_rel
+    y = center_y + sin_t * x_rel + cos_t * y_rel
+
+    return x, y
+
+
+def extract_quadrants(image, mask, center_x, center_y, angle_deg, UX, UY):
+    values = {}
+    weights = {}
+
+    for qname, sx, sy in QUADRANTS:
+        x, y = quadrant_coordinates(
+            UX,
+            UY,
+            center_x=center_x,
+            center_y=center_y,
+            angle_deg=angle_deg,
+            sx=sx,
+            sy=sy,
+        )
+
+        v, in_bounds_img = bilinear_sample(image, x, y, fill_value=0.0)
+        m, in_bounds_mask = nearest_sample(mask, x, y, fill_value=1)
+
+        valid = in_bounds_img & in_bounds_mask & (m == 0)
+
+        values[qname] = v.astype(np.float32)
+        weights[qname] = valid.astype(np.float32)
+
+    return values, weights
+
+
+def _local_fold_std_norm(folded, var, count, min_valid):
+    """Region-restricted analogue of ``_compute_fold_symmetry``'s ``fold_std_norm``.
+
+    Operates directly on the already-extracted quadrant stack (the
+    ``radius_x × radius_y`` folding grid) instead of warping/folding the whole
+    image, so the symmetry score is measured over exactly the region the ECC
+    registration sees. Returns ``None`` when the foreground cannot be
+    determined reliably (mirrors the whole-image version).
+
+    ``folded`` is the per-pixel mean across valid quadrants (the "average
+    quadrant"), ``var`` the per-pixel population variance across valid
+    quadrants (ddof=0), and ``count`` the number of valid quadrant samples per
+    pixel.
+    """
+    keep = count >= max(2, min_valid)
+    if not np.any(keep):
+        return None
+
+    per_pixel_std = np.sqrt(np.maximum(var, 0.0))
+    fold_std_sum = float(np.sum(per_pixel_std[keep]))
+
+    # Foreground = diffraction signal in the averaged quadrant, separated from
+    # background with Otsu. Denominator = total foreground signal, making the
+    # score dimensionless / exposure-independent (same as the whole-image one).
+    finite_pos = folded[keep & (folded > 0)]
+    if finite_pos.size < 100:
+        return None
+
+    aq_min = float(finite_pos.min())
+    aq_max = float(finite_pos.max())
+    if aq_max <= aq_min:
+        return None
+
+    scaled = (folded - aq_min) / (aq_max - aq_min) * 255.0
+    scaled_u8 = np.nan_to_num(scaled, nan=0.0).clip(0, 255).astype(np.uint8)
+    thresh_scaled, _ = cv2.threshold(
+        scaled_u8, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU
+    )
+    threshold = aq_min + thresh_scaled / 255.0 * (aq_max - aq_min)
+
+    fg = (folded > threshold) & keep & (folded > 0)
+    if int(np.sum(fg)) < 100:
+        return None
+
+    total_fg_signal = float(np.sum(folded[fg]))
+    if total_fg_signal <= 0:
+        return None
+
+    return fold_std_sum / total_fg_signal
+
+
+def _whole_image_fold_std_norm(image, mask, center_x, center_y, angle_deg):
+    """Whole-image ``fold_std_norm`` score, ignoring ``radius_x``/``radius_y``.
+
+    Used only for the *reported* before/after loss (see ``main``): folding the
+    entire frame — the same thing ``search-refinement-real.py`` does — keeps
+    those numbers comparable across runs with different crop sizes, even
+    though the search/registration itself is driven by the radius-restricted
+    score from ``_local_fold_std_norm``.
+    """
+    scores = _compute_fold_symmetry(
+        _image_with_mask_sentinel(image, mask),
+        (center_x, center_y),
+        angle_deg,
+    )
+    norm = scores.get("fold_std_norm")
+    return float(norm) if norm is not None else float("inf")
+
+
+def fold_and_loss(
+    image,
+    mask,
+    center_x,
+    center_y,
+    angle_deg,
+    UX,
+    UY,
+    min_valid=2,
+    *,
+    loss_mode: str = "var_mean",
+):
+    values, weights = extract_quadrants(
+        image,
+        mask,
+        center_x=center_x,
+        center_y=center_y,
+        angle_deg=angle_deg,
+        UX=UX,
+        UY=UY,
+    )
+
+    vals = np.stack([values[q] for q, _, _ in QUADRANTS], axis=0)
+    wts = np.stack([weights[q] for q, _, _ in QUADRANTS], axis=0)
+
+    count = np.sum(wts, axis=0)
+    weighted_sum = np.sum(wts * vals, axis=0)
+
+    folded = np.zeros_like(weighted_sum)
+    valid_any = count > 0
+    folded[valid_any] = weighted_sum[valid_any] / count[valid_any]
+
+    diff2 = wts * (vals - folded[None, :, :]) ** 2
+
+    var = np.zeros_like(folded)
+    var[valid_any] = np.sum(diff2, axis=0)[valid_any] / count[valid_any]
+
+    valid_loss = count >= min_valid
+
+    if not np.any(valid_loss):
+        residual = np.sqrt(np.maximum(var, 0.0))
+        return folded, count, residual, float("inf")
+
+    if loss_mode == "var_mean":
+        loss = float(np.mean(var[valid_loss]))
+
+    elif loss_mode in ("fold_std_norm", "local_fold_std_norm"):
+        # Both modes drive the search/registration from the radius_x x radius_y
+        # folding region — the same quadrants ECC registers — rather than
+        # warping/folding the whole image. (`fold_std_norm` differs only in
+        # what gets written to the final report; see `_whole_image_fold_std_norm`
+        # and its use in `main`.)
+        norm = _local_fold_std_norm(folded, var, count, min_valid)
+        loss = float(norm) if norm is not None else float("inf")
+
+    else:
+        raise ValueError(f"Unknown loss_mode: {loss_mode!r}")
+
+    residual = np.sqrt(np.maximum(var, 0.0))
+    return folded, count, residual, loss
+
+
+def transform_pattern_to_canonical(
+    image: np.ndarray,
+    mask: np.ndarray,
+    center_x: float,
+    center_y: float,
+    angle_deg: float,
+    fill_value: float = 0.0,
+) -> np.ndarray:
+    h, w = image.shape
+    cx_out = w / 2.0
+    cy_out = h / 2.0
+
+    y_out, x_out = np.mgrid[0:h, 0:w]
+    xo = x_out.astype(np.float64) - cx_out
+    yo = y_out.astype(np.float64) - cy_out
+
+    theta = math.radians(-angle_deg)
+    cos_t = math.cos(theta)
+    sin_t = math.sin(theta)
+
+    x_rel = cos_t * xo - sin_t * yo
+    y_rel = sin_t * xo + cos_t * yo
+
+    x_in = center_x + x_rel
+    y_in = center_y + y_rel
+
+    out, valid = bilinear_sample(image, x_in, y_in, fill_value=fill_value)
+    m, _ = nearest_sample(mask, x_in, y_in, fill_value=1)
+    out = np.where(valid & (m == 0), out, fill_value)
+    return out
+
+
+# ------------------------------------------------------------
+# Error metrics
+# ------------------------------------------------------------
+
+
+def wrap_angle_deg(angle):
+    return (angle + 180.0) % 360.0 - 180.0
+
+
+def read_initial_estimate_from_report(path: str):
+    """Read ``refined_estimate`` (center_xy, angle_degrees) from a prior report.
+
+    Coordinates are expected in original (full-resolution) image scale.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        report = json.load(f)
+
+    if "refined_estimate" not in report:
+        raise ValueError("init report does not contain refined_estimate")
+
+    refined = report["refined_estimate"]
+    center = refined.get("center_xy", None)
+    angle = refined.get("angle_degrees", None)
+
+    if center is None or angle is None:
+        raise ValueError("refined_estimate must contain center_xy and angle_degrees")
+
+    return [float(center[0]), float(center[1])], float(angle)
+
+
+# ------------------------------------------------------------
+# ECC registration
+# ------------------------------------------------------------
+
+
+def preprocess_for_ecc(img, weight, blur_sigma=1.0):
+    img = img.astype(np.float32)
+    w = (weight > 0).astype(np.uint8)
+
+    out = img.copy()
+    out[w == 0] = 0.0
+
+    if blur_sigma > 0:
+        k = int(max(3, 2 * round(3 * blur_sigma) + 1))
+        # Normalized ("mask-aware") Gaussian blur: smoothing the masked image and
+        # the mask separately, then dividing, prevents the zero-filled invalid
+        # region from bleeding into valid pixels and creating a false gradient
+        # ring at the mask boundary that ECC would otherwise lock onto.
+        wf = w.astype(np.float32)
+        blurred_vals = cv2.GaussianBlur(out * wf, (k, k), blur_sigma)
+        blurred_wts = cv2.GaussianBlur(wf, (k, k), blur_sigma)
+        out = np.where(blurred_wts > 1e-6, blurred_vals / blurred_wts, 0.0).astype(
+            np.float32
+        )
+        out[w == 0] = 0.0
+
+    valid = w > 0
+    if np.any(valid):
+        mean = float(np.mean(out[valid]))
+        std = float(np.std(out[valid]))
+        if std < 1e-6:
+            std = 1.0
+        out = (out - mean) / std
+        out[w == 0] = 0.0
+
+    return out.astype(np.float32), (w * 255).astype(np.uint8)
+
+
+def warp_with_ecc_matrix(moving_img, moving_w, warp_matrix, out_shape):
+    h, w = out_shape
+
+    moved = cv2.warpAffine(
+        moving_img.astype(np.float32),
+        warp_matrix,
+        (w, h),
+        flags=cv2.INTER_LINEAR + cv2.WARP_INVERSE_MAP,
+        borderMode=cv2.BORDER_CONSTANT,
+        borderValue=0,
+    )
+
+    moved_w = cv2.warpAffine(
+        moving_w.astype(np.float32),
+        warp_matrix,
+        (w, h),
+        flags=cv2.INTER_NEAREST + cv2.WARP_INVERSE_MAP,
+        borderMode=cv2.BORDER_CONSTANT,
+        borderValue=0,
+    )
+
+    moved_w = (moved_w > 0.5).astype(np.float32)
+    return moved, moved_w
+
+
+def registration_loss_after_warp(
+    moving_img, moving_w, ref_img, ref_w, warp_matrix, min_valid=100
+):
+    moved, moved_w = warp_with_ecc_matrix(
+        moving_img, moving_w, warp_matrix, ref_img.shape
+    )
+
+    valid = (moved_w > 0) & (ref_w > 0)
+    n_valid = int(np.count_nonzero(valid))
+
+    if n_valid < min_valid:
+        return float("inf"), n_valid
+
+    diff = moved[valid] - ref_img[valid]
+    loss = float(np.mean(diff * diff))
+    return loss, n_valid
+
+
+def rigid_params_from_2x3(M):
+    a = float(M[0, 0])
+    b = float(M[1, 0])
+    angle = math.degrees(math.atan2(b, a))
+    dx = float(M[0, 2])
+    dy = float(M[1, 2])
+    return dx, dy, angle
+
+
+def save_mask_debug_figure(
+    ref_img: np.ndarray,
+    ref_ecc: np.ndarray,
+    ref_mask: np.ndarray,
+    mov_img: np.ndarray,
+    mov_ecc: np.ndarray,
+    mov_mask: np.ndarray,
+    combined_mask: np.ndarray,
+    pass_index: int,
+    qname: str,
+    debug_dir: Path,
+):
+    """Save a 2×3 diagnostic figure for one (pass, quadrant) ECC registration.
+
+    Row 0: raw quadrant images with each quadrant's own mask overlaid in red.
+    Row 1: z-scored ECC inputs with the combined mask overlaid; colour-coded
+           mask comparison showing where the reference and moving masks differ.
+    """
+    debug_dir.mkdir(parents=True, exist_ok=True)
+
+    def _imshow_with_invalid_overlay(ax, img, mask_u8, cmap, title):
+        display = np.asarray(img, dtype=np.float32)
+        finite = np.isfinite(display)
+        vmin = float(np.nanmin(display[finite])) if np.any(finite) else 0.0
+        vmax = float(np.nanmax(display[finite])) if np.any(finite) else 1.0
+        if vmax <= vmin:
+            vmax = vmin + 1.0
+        ax.imshow(
+            display,
+            cmap=cmap,
+            vmin=vmin,
+            vmax=vmax,
+            origin="upper",
+            interpolation="nearest",
+        )
+        # Semi-transparent red over every invalid (masked-out) pixel.
+        invalid = (mask_u8 == 0).astype(np.float32)
+        rgba = np.zeros((*invalid.shape, 4), dtype=np.float32)
+        rgba[..., 0] = 1.0
+        rgba[..., 3] = invalid * 0.55
+        ax.imshow(rgba, origin="upper", interpolation="nearest")
+        ax.set_title(title, fontsize=8)
+        ax.axis("off")
+
+    fig, axes = plt.subplots(2, 3, figsize=(14, 9))
+    fig.suptitle(
+        f"Mask diagnostics — pass {pass_index}, quadrant {qname}\n"
+        f"Red overlay = excluded pixels",
+        fontsize=11,
+    )
+
+    _imshow_with_invalid_overlay(
+        axes[0, 0],
+        ref_img,
+        ref_mask,
+        "gray",
+        "ref image (raw)\nexcluded by ref_mask",
+    )
+    _imshow_with_invalid_overlay(
+        axes[0, 1],
+        mov_img,
+        mov_mask,
+        "gray",
+        f"mov image [{qname}] (raw)\nexcluded by mov_mask",
+    )
+
+    n_valid = int(np.count_nonzero(combined_mask))
+    n_total = int(combined_mask.size)
+    axes[0, 2].imshow(
+        combined_mask,
+        cmap="gray",
+        vmin=0,
+        vmax=255,
+        origin="upper",
+        interpolation="nearest",
+    )
+    axes[0, 2].set_title(
+        f"combined_mask (white = valid)\n{n_valid}/{n_total} = {100*n_valid/n_total:.1f}% valid",
+        fontsize=8,
+    )
+    axes[0, 2].axis("off")
+
+    _imshow_with_invalid_overlay(
+        axes[1, 0],
+        ref_ecc,
+        combined_mask,
+        "RdBu_r",
+        "ref_ecc (z-scored)\nexcluded by combined_mask",
+    )
+    _imshow_with_invalid_overlay(
+        axes[1, 1],
+        mov_ecc,
+        combined_mask,
+        "RdBu_r",
+        "mov_ecc (z-scored)\nexcluded by combined_mask",
+    )
+
+    # Colour-coded mask comparison:
+    #   white  = both valid           (passes ECC)
+    #   red    = ref invalid only     (ref masks out, mov doesn't)
+    #   blue   = mov invalid only     (mov masks out, ref doesn't)
+    #   dark   = both invalid
+    ref_valid = ref_mask > 0
+    mov_valid = mov_mask > 0
+    rgb = np.zeros((*ref_mask.shape, 3), dtype=np.float32)
+    rgb[ref_valid & mov_valid] = [1.0, 1.0, 1.0]
+    rgb[~ref_valid & mov_valid] = [1.0, 0.2, 0.2]
+    rgb[ref_valid & ~mov_valid] = [0.2, 0.4, 1.0]
+    rgb[~ref_valid & ~mov_valid] = [0.15, 0.15, 0.15]
+    axes[1, 2].imshow(rgb, origin="upper", interpolation="nearest")
+    axes[1, 2].set_title(
+        "mask comparison\nwhite=both valid | red=ref only | blue=mov only | grey=both invalid",
+        fontsize=8,
+    )
+    axes[1, 2].axis("off")
+
+    plt.tight_layout()
+    safe_qname = qname.replace("+", "p").replace("-", "m")
+    out_path = debug_dir / f"mask_debug_pass{pass_index:02d}_{safe_qname}.png"
+    plt.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def save_ecc_input_debug_images(
+    ref_ecc: np.ndarray,
+    mov_ecc: np.ndarray,
+    combined_mask: np.ndarray,
+    pass_index: int,
+    qname: str,
+    debug_dir: Path,
+):
+    """Save ref_ecc / mov_ecc / combined_mask as standalone PNGs for ECC inspection."""
+    debug_dir.mkdir(parents=True, exist_ok=True)
+    safe_qname = qname.replace("+", "p").replace("-", "m")
+    prefix = f"pass{pass_index:02d}_{safe_qname}"
+
+    def _ecc_to_bgr(ecc_img: np.ndarray) -> np.ndarray:
+        valid = combined_mask > 0
+        arr = np.asarray(ecc_img, dtype=np.float32)
+        if np.any(valid):
+            scale = max(float(np.max(np.abs(arr[valid]))), 1e-6)
+        else:
+            scale = 1.0
+        norm = np.clip(arr / scale, -1.0, 1.0)
+        gray = ((norm + 1.0) * 0.5 * 255.0).astype(np.uint8)
+        gray[~valid] = 0
+        return cv2.applyColorMap(gray, cv2.COLORMAP_TWILIGHT)
+
+    cv2.imwrite(str(debug_dir / f"ecc_ref_{prefix}.png"), _ecc_to_bgr(ref_ecc))
+    cv2.imwrite(str(debug_dir / f"ecc_mov_{prefix}.png"), _ecc_to_bgr(mov_ecc))
+    cv2.imwrite(str(debug_dir / f"ecc_combined_mask_{prefix}.png"), combined_mask)
+
+
+def ecc_register_quadrant_to_reference(
+    moving_img,
+    moving_w,
+    ref_img,
+    ref_w,
+    pass_index,
+    qname,
+    number_of_iterations=100,
+    termination_eps=1e-6,
+    blur_sigma=1.0,
+    min_valid=100,
+    erosion_px: int = 3,
+    erode_mask: bool = True,
+    reseed: bool = True,
+    debug_dir: "Path | None" = None,
+):
+    t0 = time.perf_counter()
+
+    ref_ecc, ref_mask = preprocess_for_ecc(ref_img, ref_w, blur_sigma=blur_sigma)
+    mov_ecc, mov_mask = preprocess_for_ecc(moving_img, moving_w, blur_sigma=blur_sigma)
+
+    # ECC only accepts a single (template-space) inputMask, so use the
+    # intersection of the reference and moving masks. This keeps masked-out
+    # pixels of *either* quadrant from contributing to the ECC objective.
+
+    combined_mask = cv2.bitwise_and(ref_mask, mov_mask)
+
+    # Erode the combined mask to exclude pixels adjacent to gap boundaries.
+    # Gap edges create large image gradients that ECC can lock onto instead
+    # of the diffraction pattern, causing convergence to wrong local optima.
+    erode_kernel = None
+    if erode_mask and erosion_px > 0:
+        k = 2 * erosion_px + 1
+        erode_kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (k, k))
+        combined_mask = cv2.erode(combined_mask, erode_kernel)
+
+    # Re-z-score both images over the shared valid region so both inputs
+    # have the same normalisation basis when the masks differ between quadrants.
+    combined_valid = combined_mask > 0
+    if np.any(combined_valid):
+        for ecc_img in [ref_ecc, mov_ecc]:
+            vals = ecc_img[combined_valid]
+            m = float(np.mean(vals))
+            s = float(np.std(vals))
+            if s < 1e-6:
+                s = 1.0
+            ecc_img -= m
+            ecc_img /= s
+            ecc_img[~combined_valid] = 0.0
+
+    if debug_dir is not None:
+        save_mask_debug_figure(
+            ref_img=ref_img,
+            ref_ecc=ref_ecc,
+            ref_mask=ref_mask,
+            mov_img=moving_img,
+            mov_ecc=mov_ecc,
+            mov_mask=mov_mask,
+            combined_mask=combined_mask,
+            pass_index=pass_index,
+            qname=qname,
+            debug_dir=debug_dir,
+        )
+        save_ecc_input_debug_images(
+            ref_ecc=ref_ecc,
+            mov_ecc=mov_ecc,
+            combined_mask=combined_mask,
+            pass_index=pass_index,
+            qname=qname,
+            debug_dir=debug_dir,
+        )
+
+    n_ref_valid = int(np.count_nonzero(combined_mask))
+    if n_ref_valid < min_valid:
+        runtime = time.perf_counter() - t0
+        identity = np.eye(2, 3, dtype=np.float32)
+        dx, dy, angle = rigid_params_from_2x3(identity)
+        loss, n_valid = registration_loss_after_warp(
+            moving_img, moving_w, ref_img, ref_w, identity, min_valid=min_valid
+        )
+        return {
+            "pass": pass_index,
+            "quadrant": qname,
+            "success": 0,
+            "ecc_score": float("nan"),
+            "dx": dx,
+            "dy": dy,
+            "angle_deg": angle,
+            "loss": loss,
+            "n_valid": n_valid,
+            "runtime_seconds": runtime,
+            "message": "Not enough valid reference pixels",
+            "warp_matrix": identity,
+        }
+
+    warp = np.eye(2, 3, dtype=np.float32)
+    criteria = (
+        cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT,
+        int(number_of_iterations),
+        float(termination_eps),
+    )
+
+    try:
+        ecc_score, warp = cv2.findTransformECC(
+            templateImage=ref_ecc,
+            inputImage=mov_ecc,
+            warpMatrix=warp,
+            motionType=cv2.MOTION_EUCLIDEAN,
+            criteria=criteria,
+            inputMask=combined_mask,
+            gaussFiltSize=1,
+        )
+
+        if reseed:
+            # Re-seed pass: recompute the combined mask at the found warp so the
+            # mask accurately reflects which moving pixels are valid after the
+            # transformation (the initial combined_mask was at the identity warp,
+            # which diverges from truth as the correction grows).
+            warped_mov_mask = cv2.warpAffine(
+                mov_mask.astype(np.float32),
+                warp,
+                (ref_mask.shape[1], ref_mask.shape[0]),
+                flags=cv2.INTER_NEAREST + cv2.WARP_INVERSE_MAP,
+                borderMode=cv2.BORDER_CONSTANT,
+                borderValue=0,
+            )
+            refined_combined = cv2.bitwise_and(
+                ref_mask, (warped_mov_mask > 0.5).astype(np.uint8) * 255
+            )
+            if erode_kernel is not None:
+                refined_combined = cv2.erode(refined_combined, erode_kernel)
+
+            if int(np.count_nonzero(refined_combined)) >= min_valid:
+                ecc_score2, warp = cv2.findTransformECC(
+                    templateImage=ref_ecc,
+                    inputImage=mov_ecc,
+                    warpMatrix=warp.copy(),
+                    motionType=cv2.MOTION_EUCLIDEAN,
+                    criteria=criteria,
+                    inputMask=refined_combined,
+                    gaussFiltSize=1,
+                )
+                ecc_score = ecc_score2
+
+        success = 1
+        message = "OK"
+
+    except cv2.error as e:
+        ecc_score = float("nan")
+        warp = np.eye(2, 3, dtype=np.float32)
+        success = 0
+        message = str(e).split("\n")[0]
+
+    dx, dy, angle = rigid_params_from_2x3(warp)
+
+    loss, n_valid = registration_loss_after_warp(
+        moving_img=moving_img,
+        moving_w=moving_w,
+        ref_img=ref_img,
+        ref_w=ref_w,
+        warp_matrix=warp,
+        min_valid=min_valid,
+    )
+
+    runtime = time.perf_counter() - t0
+
+    return {
+        "pass": pass_index,
+        "quadrant": qname,
+        "success": success,
+        "ecc_score": float(ecc_score) if np.isfinite(ecc_score) else float("nan"),
+        "dx": dx,
+        "dy": dy,
+        "angle_deg": angle,
+        "loss": loss,
+        "n_valid": n_valid,
+        "runtime_seconds": runtime,
+        "message": message,
+        "warp_matrix": warp.astype(np.float32),
+    }
+
+
+# ------------------------------------------------------------
+# Global correction fitting
+# ------------------------------------------------------------
+
+
+def rotation_matrix(theta_deg):
+    t = math.radians(theta_deg)
+    c = math.cos(t)
+    s = math.sin(t)
+    return np.array([[c, -s], [s, c]], dtype=np.float64)
+
+
+def sign_matrix(qname):
+    if qname == "++":
+        return np.diag([+1.0, +1.0])
+    if qname == "+-":
+        return np.diag([+1.0, -1.0])
+    if qname == "-+":
+        return np.diag([-1.0, +1.0])
+    if qname == "--":
+        return np.diag([-1.0, -1.0])
+    raise ValueError(f"Unknown quadrant {qname}")
+
+
+def homogeneous_M(center_x, center_y, angle_deg, qname):
+    R = rotation_matrix(angle_deg)
+    S = sign_matrix(qname)
+    A = R @ S
+
+    M = np.eye(3, dtype=np.float64)
+    M[0:2, 0:2] = A
+    M[0:2, 2] = [center_x, center_y]
+    return M
+
+
+def rigid_params_from_homogeneous(H):
+    A = H[0:2, 0:2]
+    dx, dy = H[0:2, 2]
+    angle = math.degrees(math.atan2(A[1, 0], A[0, 0]))
+    return float(dx), float(dy), float(angle)
+
+
+def predicted_registration_transform(
+    current_center_x,
+    current_center_y,
+    current_angle_deg,
+    dcx,
+    dcy,
+    dtheta_deg,
+    qname,
+    ref_qname="++",
+):
+    c0x = current_center_x
+    c0y = current_center_y
+    a0 = current_angle_deg
+
+    c1x = current_center_x + dcx
+    c1y = current_center_y + dcy
+    a1 = current_angle_deg + dtheta_deg
+
+    Mq0 = homogeneous_M(c0x, c0y, a0, qname)
+    Mq1 = homogeneous_M(c1x, c1y, a1, qname)
+
+    Mr0 = homogeneous_M(c0x, c0y, a0, ref_qname)
+    Mr1 = homogeneous_M(c1x, c1y, a1, ref_qname)
+
+    H = np.linalg.inv(Mq0) @ Mq1 @ np.linalg.inv(Mr1) @ Mr0
+    return H
+
+
+def global_fit_residual_vector(
+    x,
+    observed_transforms,
+    current_center,
+    current_angle_deg,
+    w_trans=1.0,
+    w_angle=10.0,
+    ref_qname="++",
+):
+    dcx, dcy, dtheta = x
+    residuals = []
+
+    for qname, obs in observed_transforms.items():
+        if qname == ref_qname:
+            continue
+
+        Hpred = predicted_registration_transform(
+            current_center_x=current_center[0],
+            current_center_y=current_center[1],
+            current_angle_deg=current_angle_deg,
+            dcx=dcx,
+            dcy=dcy,
+            dtheta_deg=dtheta,
+            qname=qname,
+            ref_qname=ref_qname,
+        )
+
+        pdx, pdy, pangle = rigid_params_from_homogeneous(Hpred)
+
+        odx = obs["dx"]
+        ody = obs["dy"]
+        oangle = obs["angle_deg"]
+        weight = math.sqrt(max(obs.get("weight", 1.0), 1e-12))
+
+        residuals.append(weight * math.sqrt(w_trans) * (odx - pdx))
+        residuals.append(weight * math.sqrt(w_trans) * (ody - pdy))
+        residuals.append(weight * math.sqrt(w_angle) * wrap_angle_deg(oangle - pangle))
+
+    if not residuals:
+        return np.array([1e6], dtype=np.float64)
+
+    return np.array(residuals, dtype=np.float64)
+
+
+def global_objective_from_residuals(res):
+    return float(np.mean(res * res))
+
+
+def fit_global_correction_ecc(
+    observed_transforms,
+    current_center,
+    current_angle_deg,
+    pass_index,
+    w_trans=1.0,
+    w_angle=10.0,
+    max_center_step=10.0,
+    max_angle_step=5.0,
+    ref_qname="++",
+):
+    t0 = time.perf_counter()
+    rows = []
+
+    def record(eval_index, candidate, is_new_best, best):
+        cand_center = [
+            current_center[0] + candidate[0],
+            current_center[1] + candidate[1],
+        ]
+        cand_angle = current_angle_deg + candidate[2]
+
+        best_center = [current_center[0] + best[0], current_center[1] + best[1]]
+        best_angle = current_angle_deg + best[2]
+
+        cand_obj = global_objective_from_residuals(
+            global_fit_residual_vector(
+                candidate,
+                observed_transforms,
+                current_center,
+                current_angle_deg,
+                w_trans=w_trans,
+                w_angle=w_angle,
+                ref_qname=ref_qname,
+            )
+        )
+        best_obj = global_objective_from_residuals(
+            global_fit_residual_vector(
+                best,
+                observed_transforms,
+                current_center,
+                current_angle_deg,
+                w_trans=w_trans,
+                w_angle=w_angle,
+                ref_qname=ref_qname,
+            )
+        )
+
+        rows.append(
+            {
+                "pass": pass_index,
+                "eval_index": eval_index,
+                "candidate_dcx": float(candidate[0]),
+                "candidate_dcy": float(candidate[1]),
+                "candidate_dtheta_deg": float(candidate[2]),
+                "candidate_center_x": float(cand_center[0]),
+                "candidate_center_y": float(cand_center[1]),
+                "candidate_angle_deg": float(cand_angle),
+                "candidate_objective": cand_obj,
+                "is_new_best": int(is_new_best),
+                "best_so_far_dcx": float(best[0]),
+                "best_so_far_dcy": float(best[1]),
+                "best_so_far_dtheta_deg": float(best[2]),
+                "best_so_far_center_x": float(best_center[0]),
+                "best_so_far_center_y": float(best_center[1]),
+                "best_so_far_angle_deg": float(best_angle),
+                "best_so_far_objective": best_obj,
+            }
+        )
+
+    if SCIPY_AVAILABLE:
+        eval_counter = {"n": 0}
+        best_x = np.array([0.0, 0.0, 0.0], dtype=np.float64)
+        best_obj = global_objective_from_residuals(
+            global_fit_residual_vector(
+                best_x,
+                observed_transforms,
+                current_center,
+                current_angle_deg,
+                w_trans=w_trans,
+                w_angle=w_angle,
+                ref_qname=ref_qname,
+            )
+        )
+
+        def fun(x):
+            res = global_fit_residual_vector(
+                x,
+                observed_transforms,
+                current_center,
+                current_angle_deg,
+                w_trans=w_trans,
+                w_angle=w_angle,
+                ref_qname=ref_qname,
+            )
+
+            obj = global_objective_from_residuals(res)
+            eval_counter["n"] += 1
+
+            nonlocal_best = False
+            if obj < eval_counter.get("best_obj", best_obj):
+                eval_counter["best_obj"] = obj
+                eval_counter["best_x"] = np.array(x, dtype=np.float64)
+                nonlocal_best = True
+
+            bx = eval_counter.get("best_x", best_x)
+            record(eval_counter["n"], np.array(x, dtype=np.float64), nonlocal_best, bx)
+            return res
+
+        bounds = (
+            np.array(
+                [-max_center_step, -max_center_step, -max_angle_step], dtype=np.float64
+            ),
+            np.array(
+                [+max_center_step, +max_center_step, +max_angle_step], dtype=np.float64
+            ),
+        )
+
+        result = least_squares(
+            fun,
+            x0=np.array([0.0, 0.0, 0.0], dtype=np.float64),
+            bounds=bounds,
+            method="trf",
+            xtol=1e-10,
+            ftol=1e-10,
+            gtol=1e-10,
+            max_nfev=200,
+        )
+
+        best = result.x.astype(np.float64)
+        best_obj = global_objective_from_residuals(
+            global_fit_residual_vector(
+                best,
+                observed_transforms,
+                current_center,
+                current_angle_deg,
+                w_trans=w_trans,
+                w_angle=w_angle,
+                ref_qname=ref_qname,
+            )
+        )
+        method = "scipy_least_squares"
+        success = bool(result.success)
+        message = str(result.message)
+
+    else:
+        method = "fallback_coordinate_search"
+        success = True
+        message = "SciPy unavailable; used fallback coordinate search."
+
+        best = np.array([0.0, 0.0, 0.0], dtype=np.float64)
+        best_obj = global_objective_from_residuals(
+            global_fit_residual_vector(
+                best,
+                observed_transforms,
+                current_center,
+                current_angle_deg,
+                w_trans=w_trans,
+                w_angle=w_angle,
+                ref_qname=ref_qname,
+            )
+        )
+
+        eval_index = 0
+        steps = [
+            np.array([2.0, 2.0, 1.0]),
+            np.array([0.5, 0.5, 0.25]),
+            np.array([0.1, 0.1, 0.05]),
+            np.array([0.03, 0.03, 0.01]),
+        ]
+
+        for step in steps:
+            improved = True
+            while improved:
+                improved = False
+                for j in range(3):
+                    for sgn in [-1.0, +1.0]:
+                        cand = best.copy()
+                        cand[j] += sgn * step[j]
+                        cand[0] = np.clip(cand[0], -max_center_step, max_center_step)
+                        cand[1] = np.clip(cand[1], -max_center_step, max_center_step)
+                        cand[2] = np.clip(cand[2], -max_angle_step, max_angle_step)
+
+                        res = global_fit_residual_vector(
+                            cand,
+                            observed_transforms,
+                            current_center,
+                            current_angle_deg,
+                            w_trans=w_trans,
+                            w_angle=w_angle,
+                        )
+                        obj = global_objective_from_residuals(res)
+                        eval_index += 1
+
+                        is_new_best = obj < best_obj
+                        if is_new_best:
+                            best = cand
+                            best_obj = obj
+                            improved = True
+
+                        record(eval_index, cand, is_new_best, best)
+
+    runtime = time.perf_counter() - t0
+
+    return {
+        "dcx": float(best[0]),
+        "dcy": float(best[1]),
+        "dtheta_deg": float(best[2]),
+        "objective": float(best_obj),
+        "method": method,
+        "success": int(success),
+        "message": message,
+        "runtime_seconds": runtime,
+        "rows": rows,
+    }
+
+
+def run_ecc_refinement(
+    image,
+    mask,
+    init_center,
+    init_angle_deg,
+    UX,
+    UY,
+    passes,
+    min_valid_fold,
+    min_valid_registration,
+    ecc_iterations,
+    ecc_eps,
+    ecc_blur_sigma,
+    w_trans,
+    w_angle,
+    max_center_step,
+    max_angle_step,
+    loss_mode: str = "var_mean",
+    erosion_px: int = 3,
+    erode_mask: bool = True,
+    reseed: bool = True,
+    dynamic_ref: bool = True,
+    verbose=True,
+    debug_dir: "Path | None" = None,
+):
+    center = [float(init_center[0]), float(init_center[1])]
+    angle = float(init_angle_deg)
+
+    all_reg_rows = []
+    all_global_rows = []
+    pass_rows = []
+
+    t0 = time.perf_counter()
+
+    _, _, _, init_loss = fold_and_loss(
+        image,
+        mask,
+        center[0],
+        center[1],
+        angle,
+        UX,
+        UY,
+        min_valid=min_valid_fold,
+        loss_mode=loss_mode,
+    )
+    best_loss = init_loss
+    best_center = list(center)
+    best_angle = angle
+    best_pass = 0  # 0 means the initial estimate is the best
+
+    for pass_index in range(1, passes + 1):
+        _, _, _, fold_loss_before = fold_and_loss(
+            image,
+            mask,
+            center[0],
+            center[1],
+            angle,
+            UX,
+            UY,
+            min_valid=min_valid_fold,
+            loss_mode=loss_mode,
+        )
+
+        values, weights = extract_quadrants(
+            image,
+            mask,
+            center_x=center[0],
+            center_y=center[1],
+            angle_deg=angle,
+            UX=UX,
+            UY=UY,
+        )
+
+        if dynamic_ref:
+            # Choose the quadrant with the most valid pixels as reference so that
+            # ECC has the largest available overlap region for all three pairs.
+            ref_qname = max(
+                ("++", "+-", "-+", "--"),
+                key=lambda q: int(np.count_nonzero(weights[q] > 0)),
+            )
+        else:
+            ref_qname = "++"
+        ref_img = values[ref_qname]
+        ref_w = weights[ref_qname]
+
+        observed = {
+            ref_qname: {
+                "dx": 0.0,
+                "dy": 0.0,
+                "angle_deg": 0.0,
+                "weight": 1.0,
+                "loss": 0.0,
+                "n_valid": int(np.count_nonzero(ref_w > 0)),
+            }
+        }
+
+        reg_runtime = 0.0
+
+        for qname in ("++", "+-", "-+", "--"):
+            if qname == ref_qname:
+                continue
+            reg = ecc_register_quadrant_to_reference(
+                moving_img=values[qname],
+                moving_w=weights[qname],
+                ref_img=ref_img,
+                ref_w=ref_w,
+                pass_index=pass_index,
+                qname=qname,
+                number_of_iterations=ecc_iterations,
+                termination_eps=ecc_eps,
+                blur_sigma=ecc_blur_sigma,
+                min_valid=min_valid_registration,
+                erosion_px=erosion_px,
+                erode_mask=erode_mask,
+                reseed=reseed,
+                debug_dir=debug_dir,
+            )
+
+            M = reg["warp_matrix"]
+
+            all_reg_rows.append(
+                {
+                    "pass": reg["pass"],
+                    "quadrant": reg["quadrant"],
+                    "success": reg["success"],
+                    "ecc_score": reg["ecc_score"],
+                    "dx": reg["dx"],
+                    "dy": reg["dy"],
+                    "angle_deg": reg["angle_deg"],
+                    "loss": reg["loss"],
+                    "n_valid": reg["n_valid"],
+                    "runtime_seconds": reg["runtime_seconds"],
+                    "message": reg["message"],
+                    "warp_00": float(M[0, 0]),
+                    "warp_01": float(M[0, 1]),
+                    "warp_02": float(M[0, 2]),
+                    "warp_10": float(M[1, 0]),
+                    "warp_11": float(M[1, 1]),
+                    "warp_12": float(M[1, 2]),
+                }
+            )
+
+            reg_runtime += reg["runtime_seconds"]
+
+            # Confidence weights how much this quadrant's observed transform is
+            # trusted in the global fit. Use the ECC score (a normalized
+            # correlation coefficient in ~[0, 1], higher = better) rather than the
+            # raw-intensity MSE, so the weighting is scale-invariant and needs no
+            # dataset-specific tuning constant.
+            if reg["success"] and np.isfinite(reg["ecc_score"]):
+                confidence = reg["n_valid"] * max(reg["ecc_score"], 0.0)
+            else:
+                confidence = 1e-6
+
+            observed[qname] = {
+                "dx": reg["dx"],
+                "dy": reg["dy"],
+                "angle_deg": reg["angle_deg"],
+                "weight": confidence,
+                "loss": reg["loss"],
+                "n_valid": reg["n_valid"],
+                "success": reg["success"],
+            }
+
+        fit = fit_global_correction_ecc(
+            observed_transforms=observed,
+            current_center=center,
+            current_angle_deg=angle,
+            pass_index=pass_index,
+            w_trans=w_trans,
+            w_angle=w_angle,
+            max_center_step=max_center_step,
+            max_angle_step=max_angle_step,
+            ref_qname=ref_qname,
+        )
+
+        all_global_rows.extend(fit["rows"])
+
+        dcx = fit["dcx"]
+        dcy = fit["dcy"]
+        dtheta = fit["dtheta_deg"]
+
+        new_center = [center[0] + dcx, center[1] + dcy]
+        new_angle = angle + dtheta
+
+        _, _, _, fold_loss_after = fold_and_loss(
+            image,
+            mask,
+            new_center[0],
+            new_center[1],
+            new_angle,
+            UX,
+            UY,
+            min_valid=min_valid_fold,
+            loss_mode=loss_mode,
+        )
+
+        is_new_best = fold_loss_after < best_loss
+        if is_new_best:
+            best_loss = fold_loss_after
+            best_center = list(new_center)
+            best_angle = new_angle
+            best_pass = pass_index
+
+        pass_rows.append(
+            {
+                "pass": pass_index,
+                "center_x_before": center[0],
+                "center_y_before": center[1],
+                "angle_before_deg": angle,
+                "fold_loss_before": fold_loss_before,
+                "dcx": dcx,
+                "dcy": dcy,
+                "dtheta_deg": dtheta,
+                "fit_objective": fit["objective"],
+                "center_x_after": new_center[0],
+                "center_y_after": new_center[1],
+                "angle_after_deg": new_angle,
+                "fold_loss_after": fold_loss_after,
+                "is_new_best": int(is_new_best),
+                "best_loss_so_far": best_loss,
+                "registration_runtime_seconds": reg_runtime,
+                "global_fit_runtime_seconds": fit["runtime_seconds"],
+            }
+        )
+
+        if verbose:
+            best_marker = " *best*" if is_new_best else ""
+            print(
+                f"Pass {pass_index}: "
+                f"dc=({dcx:.4f},{dcy:.4f}), "
+                f"dtheta={dtheta:.4f}, "
+                f"loss {fold_loss_before:.8g} -> {fold_loss_after:.8g}"
+                f"{best_marker}, "
+                f"center=({new_center[0]:.4f}, {new_center[1]:.4f}), "
+                f"angle={new_angle:.4f}"
+            )
+
+        center = new_center
+        angle = new_angle
+
+    total_runtime = time.perf_counter() - t0
+
+    return {
+        "center": center,
+        "angle_deg": angle,
+        "best_center": best_center,
+        "best_angle_deg": best_angle,
+        "best_loss": best_loss,
+        "best_pass": best_pass,
+        "init_loss": init_loss,
+        "all_registration_rows": all_reg_rows,
+        "all_global_fit_rows": all_global_rows,
+        "pass_rows": pass_rows,
+        "total_runtime_seconds": total_runtime,
+    }

--- a/musclex/algorithms/calibration_refinement/refine_center/search_refinement.py
+++ b/musclex/algorithms/calibration_refinement/refine_center/search_refinement.py
@@ -1,0 +1,599 @@
+#!/usr/bin/env python3
+"""Serial coarse-to-fine symmetry search for MuscleX calibration refinement."""
+
+from __future__ import annotations
+
+import math
+import time
+import cv2
+import numpy as np
+
+try:
+    from musclex.utils.fold_symmetry import _compute_fold_symmetry
+except Exception:
+    from utils import _compute_fold_symmetry
+
+# ------------------------------------------------------------
+# Sampling utilities
+# ------------------------------------------------------------
+
+
+def bilinear_sample(image: np.ndarray, x: np.ndarray, y: np.ndarray, fill_value=0.0):
+    h, w = image.shape
+
+    x0 = np.floor(x).astype(np.int64)
+    y0 = np.floor(y).astype(np.int64)
+    x1 = x0 + 1
+    y1 = y0 + 1
+
+    valid = (x0 >= 0) & (x1 < w) & (y0 >= 0) & (y1 < h)
+
+    x0c = np.clip(x0, 0, w - 1)
+    x1c = np.clip(x1, 0, w - 1)
+    y0c = np.clip(y0, 0, h - 1)
+    y1c = np.clip(y1, 0, h - 1)
+
+    Ia = image[y0c, x0c]
+    Ib = image[y0c, x1c]
+    Ic = image[y1c, x0c]
+    Id = image[y1c, x1c]
+
+    wa = (x1 - x) * (y1 - y)
+    wb = (x - x0) * (y1 - y)
+    wc = (x1 - x) * (y - y0)
+    wd = (x - x0) * (y - y0)
+
+    out = wa * Ia + wb * Ib + wc * Ic + wd * Id
+    out = np.where(valid, out, fill_value)
+
+    return out, valid
+
+
+def nearest_sample(mask: np.ndarray, x: np.ndarray, y: np.ndarray, fill_value=1):
+    h, w = mask.shape
+
+    xi = np.rint(x).astype(np.int64)
+    yi = np.rint(y).astype(np.int64)
+
+    valid = (xi >= 0) & (xi < w) & (yi >= 0) & (yi < h)
+
+    xic = np.clip(xi, 0, w - 1)
+    yic = np.clip(yi, 0, h - 1)
+
+    out = mask[yic, xic]
+    out = np.where(valid, out, fill_value)
+
+    return out.astype(np.uint8), valid
+
+
+# ------------------------------------------------------------
+# Geometry and folding
+# ------------------------------------------------------------
+
+
+def make_canonical_grid(width: int, height: int, radius_x=None, radius_y=None):
+    if radius_x is None:
+        radius_x = width // 2
+
+    if radius_y is None:
+        radius_y = height // 2
+
+    ux = np.arange(radius_x, dtype=np.float64)
+    uy = np.arange(radius_y, dtype=np.float64)
+
+    UY, UX = np.meshgrid(uy, ux, indexing="ij")
+    return UX, UY
+
+
+def quadrant_coordinates(UX, UY, center_x, center_y, angle_deg, sx, sy):
+    theta = math.radians(angle_deg)
+    cos_t = math.cos(theta)
+    sin_t = math.sin(theta)
+
+    x_rel = sx * UX
+    y_rel = sy * UY
+
+    x = center_x + cos_t * x_rel - sin_t * y_rel
+    y = center_y + sin_t * x_rel + cos_t * y_rel
+
+    return x, y
+
+
+def extract_quadrants(image, mask, center_x, center_y, angle_deg, UX, UY):
+    signs = [
+        (+1, +1),
+        (+1, -1),
+        (-1, +1),
+        (-1, -1),
+    ]
+
+    vals = []
+    weights = []
+
+    for sx, sy in signs:
+        x, y = quadrant_coordinates(
+            UX,
+            UY,
+            center_x=center_x,
+            center_y=center_y,
+            angle_deg=angle_deg,
+            sx=sx,
+            sy=sy,
+        )
+
+        v, in_bounds_img = bilinear_sample(image, x, y, fill_value=0.0)
+        m, in_bounds_mask = nearest_sample(mask, x, y, fill_value=1)
+
+        valid = in_bounds_img & in_bounds_mask & (m == 0)
+
+        vals.append(v)
+        weights.append(valid.astype(np.float64))
+
+    return np.stack(vals, axis=0), np.stack(weights, axis=0)
+
+
+def _image_with_mask_sentinel(image: np.ndarray, mask: np.ndarray) -> np.ndarray:
+    """Return *image* with masked-out pixels set to a sentinel ``_compute_fold_symmetry``
+    treats as invalid (``<= INVALID_PIXEL_THRESHOLD = -1``). When the mask has no
+    invalid pixels, the original array is returned without copying."""
+    if mask is None or not mask.any():
+        return image
+    out = image.astype(np.float64, copy=True)
+    out[mask != 0] = -1.0
+    return out
+
+
+def _local_fold_std_norm(folded, var, count, min_valid):
+    """Region-restricted analogue of ``_compute_fold_symmetry``'s ``fold_std_norm``.
+
+    Operates directly on the already-extracted quadrant stack (the
+    ``radius_x x radius_y`` folding grid) instead of warping/folding the whole
+    image, so the symmetry score is measured over exactly the region the
+    search samples. Returns ``None`` when the foreground cannot be determined
+    reliably (mirrors the whole-image version).
+
+    ``folded`` is the per-pixel mean across valid quadrants (the "average
+    quadrant"), ``var`` the per-pixel population variance across valid
+    quadrants (ddof=0), and ``count`` the number of valid quadrant samples per
+    pixel.
+    """
+    keep = count >= max(2, min_valid)
+    if not np.any(keep):
+        return None
+
+    per_pixel_std = np.sqrt(np.maximum(var, 0.0))
+    fold_std_sum = float(np.sum(per_pixel_std[keep]))
+
+    # Foreground = diffraction signal in the averaged quadrant, separated from
+    # background with Otsu. Denominator = total foreground signal, making the
+    # score dimensionless / exposure-independent (same as the whole-image one).
+    finite_pos = folded[keep & (folded > 0)]
+    if finite_pos.size < 100:
+        return None
+
+    aq_min = float(finite_pos.min())
+    aq_max = float(finite_pos.max())
+    if aq_max <= aq_min:
+        return None
+
+    scaled = (folded - aq_min) / (aq_max - aq_min) * 255.0
+    scaled_u8 = np.nan_to_num(scaled, nan=0.0).clip(0, 255).astype(np.uint8)
+    thresh_scaled, _ = cv2.threshold(
+        scaled_u8, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU
+    )
+    threshold = aq_min + thresh_scaled / 255.0 * (aq_max - aq_min)
+
+    fg = (folded > threshold) & keep & (folded > 0)
+    if int(np.sum(fg)) < 100:
+        return None
+
+    total_fg_signal = float(np.sum(folded[fg]))
+    if total_fg_signal <= 0:
+        return None
+
+    return fold_std_sum / total_fg_signal
+
+
+def _whole_image_fold_std_norm(image, mask, center_x, center_y, angle_deg):
+    """Whole-image ``fold_std_norm`` score, ignoring ``radius_x``/``radius_y``.
+
+    Used only for the *reported* before/after loss (see ``main``): folding the
+    entire frame keeps those numbers comparable across runs with different
+    crop sizes and with the other refinement scripts, even though the search
+    itself is driven by the radius-restricted score from
+    ``_local_fold_std_norm``.
+    """
+    scores = _compute_fold_symmetry(
+        _image_with_mask_sentinel(image, mask),
+        (center_x, center_y),
+        angle_deg,
+    )
+    norm = scores.get("fold_std_norm")
+    return float(norm) if norm is not None else float("inf")
+
+
+def fold_and_loss(
+    image,
+    mask,
+    center_x,
+    center_y,
+    angle_deg,
+    UX,
+    UY,
+    min_valid=2,
+    *,
+    loss_mode: str = "var_mean",
+):
+    vals, weights = extract_quadrants(
+        image=image,
+        mask=mask,
+        center_x=center_x,
+        center_y=center_y,
+        angle_deg=angle_deg,
+        UX=UX,
+        UY=UY,
+    )
+
+    count = np.sum(weights, axis=0)
+    weighted_sum = np.sum(weights * vals, axis=0)
+
+    folded = np.zeros_like(weighted_sum)
+    valid_any = count > 0
+    folded[valid_any] = weighted_sum[valid_any] / count[valid_any]
+
+    diff2 = weights * (vals - folded[None, :, :]) ** 2
+
+    var = np.zeros_like(folded)
+    var[valid_any] = np.sum(diff2, axis=0)[valid_any] / count[valid_any]
+
+    valid_loss = count >= min_valid
+
+    if not np.any(valid_loss):
+        residual = np.sqrt(np.maximum(var, 0.0))
+        return folded, count, residual, float("inf")
+
+    if loss_mode == "var_mean":
+        loss = float(np.mean(var[valid_loss]))
+
+    elif loss_mode == "fold_std_norm":
+        # Drive the search from the radius_x x radius_y folding region — the
+        # same quadrants the search samples — rather than warping/folding the
+        # whole image; see `_whole_image_fold_std_norm` for the whole-image
+        # score used for the final reported loss in `main`.
+        norm = _local_fold_std_norm(folded, var, count, min_valid)
+        loss = float(norm) if norm is not None else float("inf")
+
+    else:
+        raise ValueError(f"Unknown loss_mode: {loss_mode!r}")
+
+    residual = np.sqrt(np.maximum(var, 0.0))
+
+    return folded, count, residual, loss
+
+
+def transform_pattern_to_canonical(
+    image: np.ndarray,
+    mask: np.ndarray,
+    center_x: float,
+    center_y: float,
+    angle_deg: float,
+    fill_value: float = 0.0,
+) -> np.ndarray:
+    """Warp *image* so the symmetry center sits at the image center with zero rotation.
+
+    For each output pixel, inverse-map through rotation then translation (same
+    convention as Musclex ``QuadrantFolder.transformImage`` / ``fold_symmetry``).
+    """
+    h, w = image.shape
+    cx_out = w / 2.0
+    cy_out = h / 2.0
+
+    y_out, x_out = np.mgrid[0:h, 0:w]
+    xo = x_out.astype(np.float64) - cx_out
+    yo = y_out.astype(np.float64) - cy_out
+
+    theta = math.radians(-angle_deg)
+    cos_t = math.cos(theta)
+    sin_t = math.sin(theta)
+
+    x_rel = cos_t * xo - sin_t * yo
+    y_rel = sin_t * xo + cos_t * yo
+
+    x_in = center_x + x_rel
+    y_in = center_y + y_rel
+
+    out, valid = bilinear_sample(image, x_in, y_in, fill_value=fill_value)
+    m, _ = nearest_sample(mask, x_in, y_in, fill_value=1)
+    out = np.where(valid & (m == 0), out, fill_value)
+    return out
+
+
+# ------------------------------------------------------------
+# Grid-search utilities
+# ------------------------------------------------------------
+
+
+def parse_levels(levels_str):
+    levels = []
+
+    for part in levels_str.split(","):
+        vals = part.strip().split(":")
+        if len(vals) != 4:
+            raise ValueError(
+                "Each level must have format center_range:center_step:angle_range:angle_step"
+            )
+
+        cr, cs, ar, astep = map(float, vals)
+
+        if cr < 0 or ar < 0 or cs <= 0 or astep <= 0:
+            raise ValueError("Ranges must be nonnegative and steps must be positive.")
+
+        levels.append(
+            {
+                "center_range": cr,
+                "center_step": cs,
+                "angle_range": ar,
+                "angle_step": astep,
+            }
+        )
+
+    return levels
+
+
+def parse_angle_only_levels(levels_str):
+    """Parse angle-only levels format: 'angle_range:angle_step,...'
+
+    Returns the same dict structure as ``parse_levels`` but with
+    ``center_range=0`` so the center is never moved during the search.
+    """
+    levels = []
+    for part in levels_str.split(","):
+        vals = part.strip().split(":")
+        if len(vals) != 2:
+            raise ValueError(
+                "Each angle-only level must have format angle_range:angle_step"
+            )
+        ar, astep = map(float, vals)
+        if ar < 0 or astep <= 0:
+            raise ValueError("Range must be nonnegative and step must be positive.")
+        levels.append(
+            {
+                "center_range": 0.0,
+                "center_step": 1.0,
+                "angle_range": ar,
+                "angle_step": astep,
+            }
+        )
+    return levels
+
+
+def make_offsets(search_range, step):
+    n = int(round((2.0 * search_range) / step))
+    vals = -search_range + step * np.arange(n + 1, dtype=np.float64)
+    vals[np.argmin(np.abs(vals))] = 0.0
+    return vals
+
+
+ALL_EVAL_FIELDNAMES = [
+    "global_eval_index",
+    "level",
+    "level_eval_index",
+    "level_start_center_x",
+    "level_start_center_y",
+    "level_start_angle_deg",
+    "dx",
+    "dy",
+    "dtheta_deg",
+    "candidate_center_x",
+    "candidate_center_y",
+    "candidate_angle_deg",
+    "candidate_loss",
+    "is_new_best",
+    "best_so_far_center_x",
+    "best_so_far_center_y",
+    "best_so_far_angle_deg",
+    "best_so_far_loss",
+]
+
+
+def coarse_to_fine_search(
+    image,
+    mask,
+    init_center,
+    init_angle_deg,
+    UX,
+    UY,
+    levels,
+    min_valid=2,
+    loss_mode: str = "var_mean",
+    verbose=True,
+):
+    best_center_x, best_center_y = init_center
+    best_angle = init_angle_deg
+
+    history = []
+    all_eval_rows = []
+
+    global_eval_index = 0
+    total_evals = 0
+
+    t0 = time.perf_counter()
+
+    _, _, _, best_loss = fold_and_loss(
+        image,
+        mask,
+        best_center_x,
+        best_center_y,
+        best_angle,
+        UX,
+        UY,
+        min_valid=min_valid,
+        loss_mode=loss_mode,
+    )
+
+    all_eval_rows.append(
+        {
+            "global_eval_index": global_eval_index,
+            "level": 0,
+            "level_eval_index": 0,
+            "level_start_center_x": best_center_x,
+            "level_start_center_y": best_center_y,
+            "level_start_angle_deg": best_angle,
+            "dx": 0.0,
+            "dy": 0.0,
+            "dtheta_deg": 0.0,
+            "candidate_center_x": best_center_x,
+            "candidate_center_y": best_center_y,
+            "candidate_angle_deg": best_angle,
+            "candidate_loss": best_loss,
+            "is_new_best": 1,
+            "best_so_far_center_x": best_center_x,
+            "best_so_far_center_y": best_center_y,
+            "best_so_far_angle_deg": best_angle,
+            "best_so_far_loss": best_loss,
+        }
+    )
+
+    if verbose:
+        print(f"Initial loss: {best_loss:.8g}")
+
+    for level_index, level in enumerate(levels, start=1):
+        cr = level["center_range"]
+        cs = level["center_step"]
+        ar = level["angle_range"]
+        astep = level["angle_step"]
+
+        dxs = make_offsets(cr, cs)
+        dys = make_offsets(cr, cs)
+        dts = make_offsets(ar, astep)
+
+        level_start_center_x = best_center_x
+        level_start_center_y = best_center_y
+        level_start_angle = best_angle
+
+        level_best = {
+            "loss": best_loss,
+            "center_x": best_center_x,
+            "center_y": best_center_y,
+            "angle_deg": best_angle,
+            "dx_from_level_start": 0.0,
+            "dy_from_level_start": 0.0,
+            "dtheta_from_level_start": 0.0,
+        }
+
+        level_t0 = time.perf_counter()
+        level_eval_index = 0
+
+        for dtheta in dts:
+            cand_angle = level_start_angle + dtheta
+
+            for dy in dys:
+                cand_y = level_start_center_y + dy
+
+                for dx in dxs:
+                    cand_x = level_start_center_x + dx
+
+                    _, _, _, loss = fold_and_loss(
+                        image,
+                        mask,
+                        cand_x,
+                        cand_y,
+                        cand_angle,
+                        UX,
+                        UY,
+                        min_valid=min_valid,
+                        loss_mode=loss_mode,
+                    )
+
+                    global_eval_index += 1
+                    level_eval_index += 1
+                    total_evals += 1
+
+                    is_new_best = loss < best_loss
+
+                    if is_new_best:
+                        best_center_x = float(cand_x)
+                        best_center_y = float(cand_y)
+                        best_angle = float(cand_angle)
+                        best_loss = float(loss)
+
+                    all_eval_rows.append(
+                        {
+                            "global_eval_index": global_eval_index,
+                            "level": level_index,
+                            "level_eval_index": level_eval_index,
+                            "level_start_center_x": level_start_center_x,
+                            "level_start_center_y": level_start_center_y,
+                            "level_start_angle_deg": level_start_angle,
+                            "dx": float(dx),
+                            "dy": float(dy),
+                            "dtheta_deg": float(dtheta),
+                            "candidate_center_x": float(cand_x),
+                            "candidate_center_y": float(cand_y),
+                            "candidate_angle_deg": float(cand_angle),
+                            "candidate_loss": float(loss),
+                            "is_new_best": int(is_new_best),
+                            "best_so_far_center_x": best_center_x,
+                            "best_so_far_center_y": best_center_y,
+                            "best_so_far_angle_deg": best_angle,
+                            "best_so_far_loss": best_loss,
+                        }
+                    )
+
+                    if loss < level_best["loss"]:
+                        level_best = {
+                            "loss": float(loss),
+                            "center_x": float(cand_x),
+                            "center_y": float(cand_y),
+                            "angle_deg": float(cand_angle),
+                            "dx_from_level_start": float(dx),
+                            "dy_from_level_start": float(dy),
+                            "dtheta_from_level_start": float(dtheta),
+                        }
+
+        level_time = time.perf_counter() - level_t0
+
+        history.append(
+            {
+                "level": level_index,
+                "center_range_pixels": cr,
+                "center_step_pixels": cs,
+                "angle_range_degrees": ar,
+                "angle_step_degrees": astep,
+                "num_dx": len(dxs),
+                "num_dy": len(dys),
+                "num_dtheta": len(dts),
+                "num_evaluations": level_eval_index,
+                "runtime_seconds": level_time,
+                "best": {
+                    "loss": best_loss,
+                    "center_x": best_center_x,
+                    "center_y": best_center_y,
+                    "angle_deg": best_angle,
+                },
+                "level_best": level_best,
+            }
+        )
+
+        if verbose:
+            print(
+                f"Level {level_index}: "
+                f"evals={level_eval_index}, "
+                f"time={level_time:.2f}s, "
+                f"best_loss={best_loss:.8g}, "
+                f"center=({best_center_x:.4f}, {best_center_y:.4f}), "
+                f"angle={best_angle:.4f}"
+            )
+
+    total_time = time.perf_counter() - t0
+
+    return {
+        "center_x": float(best_center_x),
+        "center_y": float(best_center_y),
+        "angle_deg": float(best_angle),
+        "loss": float(best_loss),
+        "history": history,
+        "all_evaluations": all_eval_rows,
+        "total_evaluations": total_evals,
+        "total_runtime_seconds": total_time,
+    }

--- a/musclex/algorithms/calibration_refinement/refine_rotation.py
+++ b/musclex/algorithms/calibration_refinement/refine_rotation.py
@@ -1,0 +1,599 @@
+#!/usr/bin/env python3
+"""Serial coarse-to-fine symmetry search for MuscleX calibration refinement."""
+
+from __future__ import annotations
+
+import math
+import time
+import cv2
+import numpy as np
+
+try:
+    from musclex.utils.fold_symmetry import _compute_fold_symmetry
+except Exception:
+    from utils import _compute_fold_symmetry
+
+# ------------------------------------------------------------
+# Sampling utilities
+# ------------------------------------------------------------
+
+
+def bilinear_sample(image: np.ndarray, x: np.ndarray, y: np.ndarray, fill_value=0.0):
+    h, w = image.shape
+
+    x0 = np.floor(x).astype(np.int64)
+    y0 = np.floor(y).astype(np.int64)
+    x1 = x0 + 1
+    y1 = y0 + 1
+
+    valid = (x0 >= 0) & (x1 < w) & (y0 >= 0) & (y1 < h)
+
+    x0c = np.clip(x0, 0, w - 1)
+    x1c = np.clip(x1, 0, w - 1)
+    y0c = np.clip(y0, 0, h - 1)
+    y1c = np.clip(y1, 0, h - 1)
+
+    Ia = image[y0c, x0c]
+    Ib = image[y0c, x1c]
+    Ic = image[y1c, x0c]
+    Id = image[y1c, x1c]
+
+    wa = (x1 - x) * (y1 - y)
+    wb = (x - x0) * (y1 - y)
+    wc = (x1 - x) * (y - y0)
+    wd = (x - x0) * (y - y0)
+
+    out = wa * Ia + wb * Ib + wc * Ic + wd * Id
+    out = np.where(valid, out, fill_value)
+
+    return out, valid
+
+
+def nearest_sample(mask: np.ndarray, x: np.ndarray, y: np.ndarray, fill_value=1):
+    h, w = mask.shape
+
+    xi = np.rint(x).astype(np.int64)
+    yi = np.rint(y).astype(np.int64)
+
+    valid = (xi >= 0) & (xi < w) & (yi >= 0) & (yi < h)
+
+    xic = np.clip(xi, 0, w - 1)
+    yic = np.clip(yi, 0, h - 1)
+
+    out = mask[yic, xic]
+    out = np.where(valid, out, fill_value)
+
+    return out.astype(np.uint8), valid
+
+
+# ------------------------------------------------------------
+# Geometry and folding
+# ------------------------------------------------------------
+
+
+def make_canonical_grid(width: int, height: int, radius_x=None, radius_y=None):
+    if radius_x is None:
+        radius_x = width // 2
+
+    if radius_y is None:
+        radius_y = height // 2
+
+    ux = np.arange(radius_x, dtype=np.float64)
+    uy = np.arange(radius_y, dtype=np.float64)
+
+    UY, UX = np.meshgrid(uy, ux, indexing="ij")
+    return UX, UY
+
+
+def quadrant_coordinates(UX, UY, center_x, center_y, angle_deg, sx, sy):
+    theta = math.radians(angle_deg)
+    cos_t = math.cos(theta)
+    sin_t = math.sin(theta)
+
+    x_rel = sx * UX
+    y_rel = sy * UY
+
+    x = center_x + cos_t * x_rel - sin_t * y_rel
+    y = center_y + sin_t * x_rel + cos_t * y_rel
+
+    return x, y
+
+
+def extract_quadrants(image, mask, center_x, center_y, angle_deg, UX, UY):
+    signs = [
+        (+1, +1),
+        (+1, -1),
+        (-1, +1),
+        (-1, -1),
+    ]
+
+    vals = []
+    weights = []
+
+    for sx, sy in signs:
+        x, y = quadrant_coordinates(
+            UX,
+            UY,
+            center_x=center_x,
+            center_y=center_y,
+            angle_deg=angle_deg,
+            sx=sx,
+            sy=sy,
+        )
+
+        v, in_bounds_img = bilinear_sample(image, x, y, fill_value=0.0)
+        m, in_bounds_mask = nearest_sample(mask, x, y, fill_value=1)
+
+        valid = in_bounds_img & in_bounds_mask & (m == 0)
+
+        vals.append(v)
+        weights.append(valid.astype(np.float64))
+
+    return np.stack(vals, axis=0), np.stack(weights, axis=0)
+
+
+def _image_with_mask_sentinel(image: np.ndarray, mask: np.ndarray) -> np.ndarray:
+    """Return *image* with masked-out pixels set to a sentinel ``_compute_fold_symmetry``
+    treats as invalid (``<= INVALID_PIXEL_THRESHOLD = -1``). When the mask has no
+    invalid pixels, the original array is returned without copying."""
+    if mask is None or not mask.any():
+        return image
+    out = image.astype(np.float64, copy=True)
+    out[mask != 0] = -1.0
+    return out
+
+
+def _local_fold_std_norm(folded, var, count, min_valid):
+    """Region-restricted analogue of ``_compute_fold_symmetry``'s ``fold_std_norm``.
+
+    Operates directly on the already-extracted quadrant stack (the
+    ``radius_x x radius_y`` folding grid) instead of warping/folding the whole
+    image, so the symmetry score is measured over exactly the region the
+    search samples. Returns ``None`` when the foreground cannot be determined
+    reliably (mirrors the whole-image version).
+
+    ``folded`` is the per-pixel mean across valid quadrants (the "average
+    quadrant"), ``var`` the per-pixel population variance across valid
+    quadrants (ddof=0), and ``count`` the number of valid quadrant samples per
+    pixel.
+    """
+    keep = count >= max(2, min_valid)
+    if not np.any(keep):
+        return None
+
+    per_pixel_std = np.sqrt(np.maximum(var, 0.0))
+    fold_std_sum = float(np.sum(per_pixel_std[keep]))
+
+    # Foreground = diffraction signal in the averaged quadrant, separated from
+    # background with Otsu. Denominator = total foreground signal, making the
+    # score dimensionless / exposure-independent (same as the whole-image one).
+    finite_pos = folded[keep & (folded > 0)]
+    if finite_pos.size < 100:
+        return None
+
+    aq_min = float(finite_pos.min())
+    aq_max = float(finite_pos.max())
+    if aq_max <= aq_min:
+        return None
+
+    scaled = (folded - aq_min) / (aq_max - aq_min) * 255.0
+    scaled_u8 = np.nan_to_num(scaled, nan=0.0).clip(0, 255).astype(np.uint8)
+    thresh_scaled, _ = cv2.threshold(
+        scaled_u8, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU
+    )
+    threshold = aq_min + thresh_scaled / 255.0 * (aq_max - aq_min)
+
+    fg = (folded > threshold) & keep & (folded > 0)
+    if int(np.sum(fg)) < 100:
+        return None
+
+    total_fg_signal = float(np.sum(folded[fg]))
+    if total_fg_signal <= 0:
+        return None
+
+    return fold_std_sum / total_fg_signal
+
+
+def _whole_image_fold_std_norm(image, mask, center_x, center_y, angle_deg):
+    """Whole-image ``fold_std_norm`` score, ignoring ``radius_x``/``radius_y``.
+
+    Used only for the *reported* before/after loss (see ``main``): folding the
+    entire frame keeps those numbers comparable across runs with different
+    crop sizes and with the other refinement scripts, even though the search
+    itself is driven by the radius-restricted score from
+    ``_local_fold_std_norm``.
+    """
+    scores = _compute_fold_symmetry(
+        _image_with_mask_sentinel(image, mask),
+        (center_x, center_y),
+        angle_deg,
+    )
+    norm = scores.get("fold_std_norm")
+    return float(norm) if norm is not None else float("inf")
+
+
+def fold_and_loss(
+    image,
+    mask,
+    center_x,
+    center_y,
+    angle_deg,
+    UX,
+    UY,
+    min_valid=2,
+    *,
+    loss_mode: str = "var_mean",
+):
+    vals, weights = extract_quadrants(
+        image=image,
+        mask=mask,
+        center_x=center_x,
+        center_y=center_y,
+        angle_deg=angle_deg,
+        UX=UX,
+        UY=UY,
+    )
+
+    count = np.sum(weights, axis=0)
+    weighted_sum = np.sum(weights * vals, axis=0)
+
+    folded = np.zeros_like(weighted_sum)
+    valid_any = count > 0
+    folded[valid_any] = weighted_sum[valid_any] / count[valid_any]
+
+    diff2 = weights * (vals - folded[None, :, :]) ** 2
+
+    var = np.zeros_like(folded)
+    var[valid_any] = np.sum(diff2, axis=0)[valid_any] / count[valid_any]
+
+    valid_loss = count >= min_valid
+
+    if not np.any(valid_loss):
+        residual = np.sqrt(np.maximum(var, 0.0))
+        return folded, count, residual, float("inf")
+
+    if loss_mode == "var_mean":
+        loss = float(np.mean(var[valid_loss]))
+
+    elif loss_mode == "fold_std_norm":
+        # Drive the search from the radius_x x radius_y folding region — the
+        # same quadrants the search samples — rather than warping/folding the
+        # whole image; see `_whole_image_fold_std_norm` for the whole-image
+        # score used for the final reported loss in `main`.
+        norm = _local_fold_std_norm(folded, var, count, min_valid)
+        loss = float(norm) if norm is not None else float("inf")
+
+    else:
+        raise ValueError(f"Unknown loss_mode: {loss_mode!r}")
+
+    residual = np.sqrt(np.maximum(var, 0.0))
+
+    return folded, count, residual, loss
+
+
+def transform_pattern_to_canonical(
+    image: np.ndarray,
+    mask: np.ndarray,
+    center_x: float,
+    center_y: float,
+    angle_deg: float,
+    fill_value: float = 0.0,
+) -> np.ndarray:
+    """Warp *image* so the symmetry center sits at the image center with zero rotation.
+
+    For each output pixel, inverse-map through rotation then translation (same
+    convention as Musclex ``QuadrantFolder.transformImage`` / ``fold_symmetry``).
+    """
+    h, w = image.shape
+    cx_out = w / 2.0
+    cy_out = h / 2.0
+
+    y_out, x_out = np.mgrid[0:h, 0:w]
+    xo = x_out.astype(np.float64) - cx_out
+    yo = y_out.astype(np.float64) - cy_out
+
+    theta = math.radians(-angle_deg)
+    cos_t = math.cos(theta)
+    sin_t = math.sin(theta)
+
+    x_rel = cos_t * xo - sin_t * yo
+    y_rel = sin_t * xo + cos_t * yo
+
+    x_in = center_x + x_rel
+    y_in = center_y + y_rel
+
+    out, valid = bilinear_sample(image, x_in, y_in, fill_value=fill_value)
+    m, _ = nearest_sample(mask, x_in, y_in, fill_value=1)
+    out = np.where(valid & (m == 0), out, fill_value)
+    return out
+
+
+# ------------------------------------------------------------
+# Grid-search utilities
+# ------------------------------------------------------------
+
+
+def parse_levels(levels_str):
+    levels = []
+
+    for part in levels_str.split(","):
+        vals = part.strip().split(":")
+        if len(vals) != 4:
+            raise ValueError(
+                "Each level must have format center_range:center_step:angle_range:angle_step"
+            )
+
+        cr, cs, ar, astep = map(float, vals)
+
+        if cr < 0 or ar < 0 or cs <= 0 or astep <= 0:
+            raise ValueError("Ranges must be nonnegative and steps must be positive.")
+
+        levels.append(
+            {
+                "center_range": cr,
+                "center_step": cs,
+                "angle_range": ar,
+                "angle_step": astep,
+            }
+        )
+
+    return levels
+
+
+def parse_angle_only_levels(levels_str):
+    """Parse angle-only levels format: 'angle_range:angle_step,...'
+
+    Returns the same dict structure as ``parse_levels`` but with
+    ``center_range=0`` so the center is never moved during the search.
+    """
+    levels = []
+    for part in levels_str.split(","):
+        vals = part.strip().split(":")
+        if len(vals) != 2:
+            raise ValueError(
+                "Each angle-only level must have format angle_range:angle_step"
+            )
+        ar, astep = map(float, vals)
+        if ar < 0 or astep <= 0:
+            raise ValueError("Range must be nonnegative and step must be positive.")
+        levels.append(
+            {
+                "center_range": 0.0,
+                "center_step": 1.0,
+                "angle_range": ar,
+                "angle_step": astep,
+            }
+        )
+    return levels
+
+
+def make_offsets(search_range, step):
+    n = int(round((2.0 * search_range) / step))
+    vals = -search_range + step * np.arange(n + 1, dtype=np.float64)
+    vals[np.argmin(np.abs(vals))] = 0.0
+    return vals
+
+
+ALL_EVAL_FIELDNAMES = [
+    "global_eval_index",
+    "level",
+    "level_eval_index",
+    "level_start_center_x",
+    "level_start_center_y",
+    "level_start_angle_deg",
+    "dx",
+    "dy",
+    "dtheta_deg",
+    "candidate_center_x",
+    "candidate_center_y",
+    "candidate_angle_deg",
+    "candidate_loss",
+    "is_new_best",
+    "best_so_far_center_x",
+    "best_so_far_center_y",
+    "best_so_far_angle_deg",
+    "best_so_far_loss",
+]
+
+
+def coarse_to_fine_search(
+    image,
+    mask,
+    init_center,
+    init_angle_deg,
+    UX,
+    UY,
+    levels,
+    min_valid=2,
+    loss_mode: str = "var_mean",
+    verbose=True,
+):
+    best_center_x, best_center_y = init_center
+    best_angle = init_angle_deg
+
+    history = []
+    all_eval_rows = []
+
+    global_eval_index = 0
+    total_evals = 0
+
+    t0 = time.perf_counter()
+
+    _, _, _, best_loss = fold_and_loss(
+        image,
+        mask,
+        best_center_x,
+        best_center_y,
+        best_angle,
+        UX,
+        UY,
+        min_valid=min_valid,
+        loss_mode=loss_mode,
+    )
+
+    all_eval_rows.append(
+        {
+            "global_eval_index": global_eval_index,
+            "level": 0,
+            "level_eval_index": 0,
+            "level_start_center_x": best_center_x,
+            "level_start_center_y": best_center_y,
+            "level_start_angle_deg": best_angle,
+            "dx": 0.0,
+            "dy": 0.0,
+            "dtheta_deg": 0.0,
+            "candidate_center_x": best_center_x,
+            "candidate_center_y": best_center_y,
+            "candidate_angle_deg": best_angle,
+            "candidate_loss": best_loss,
+            "is_new_best": 1,
+            "best_so_far_center_x": best_center_x,
+            "best_so_far_center_y": best_center_y,
+            "best_so_far_angle_deg": best_angle,
+            "best_so_far_loss": best_loss,
+        }
+    )
+
+    if verbose:
+        print(f"Initial loss: {best_loss:.8g}")
+
+    for level_index, level in enumerate(levels, start=1):
+        cr = level["center_range"]
+        cs = level["center_step"]
+        ar = level["angle_range"]
+        astep = level["angle_step"]
+
+        dxs = make_offsets(cr, cs)
+        dys = make_offsets(cr, cs)
+        dts = make_offsets(ar, astep)
+
+        level_start_center_x = best_center_x
+        level_start_center_y = best_center_y
+        level_start_angle = best_angle
+
+        level_best = {
+            "loss": best_loss,
+            "center_x": best_center_x,
+            "center_y": best_center_y,
+            "angle_deg": best_angle,
+            "dx_from_level_start": 0.0,
+            "dy_from_level_start": 0.0,
+            "dtheta_from_level_start": 0.0,
+        }
+
+        level_t0 = time.perf_counter()
+        level_eval_index = 0
+
+        for dtheta in dts:
+            cand_angle = level_start_angle + dtheta
+
+            for dy in dys:
+                cand_y = level_start_center_y + dy
+
+                for dx in dxs:
+                    cand_x = level_start_center_x + dx
+
+                    _, _, _, loss = fold_and_loss(
+                        image,
+                        mask,
+                        cand_x,
+                        cand_y,
+                        cand_angle,
+                        UX,
+                        UY,
+                        min_valid=min_valid,
+                        loss_mode=loss_mode,
+                    )
+
+                    global_eval_index += 1
+                    level_eval_index += 1
+                    total_evals += 1
+
+                    is_new_best = loss < best_loss
+
+                    if is_new_best:
+                        best_center_x = float(cand_x)
+                        best_center_y = float(cand_y)
+                        best_angle = float(cand_angle)
+                        best_loss = float(loss)
+
+                    all_eval_rows.append(
+                        {
+                            "global_eval_index": global_eval_index,
+                            "level": level_index,
+                            "level_eval_index": level_eval_index,
+                            "level_start_center_x": level_start_center_x,
+                            "level_start_center_y": level_start_center_y,
+                            "level_start_angle_deg": level_start_angle,
+                            "dx": float(dx),
+                            "dy": float(dy),
+                            "dtheta_deg": float(dtheta),
+                            "candidate_center_x": float(cand_x),
+                            "candidate_center_y": float(cand_y),
+                            "candidate_angle_deg": float(cand_angle),
+                            "candidate_loss": float(loss),
+                            "is_new_best": int(is_new_best),
+                            "best_so_far_center_x": best_center_x,
+                            "best_so_far_center_y": best_center_y,
+                            "best_so_far_angle_deg": best_angle,
+                            "best_so_far_loss": best_loss,
+                        }
+                    )
+
+                    if loss < level_best["loss"]:
+                        level_best = {
+                            "loss": float(loss),
+                            "center_x": float(cand_x),
+                            "center_y": float(cand_y),
+                            "angle_deg": float(cand_angle),
+                            "dx_from_level_start": float(dx),
+                            "dy_from_level_start": float(dy),
+                            "dtheta_from_level_start": float(dtheta),
+                        }
+
+        level_time = time.perf_counter() - level_t0
+
+        history.append(
+            {
+                "level": level_index,
+                "center_range_pixels": cr,
+                "center_step_pixels": cs,
+                "angle_range_degrees": ar,
+                "angle_step_degrees": astep,
+                "num_dx": len(dxs),
+                "num_dy": len(dys),
+                "num_dtheta": len(dts),
+                "num_evaluations": level_eval_index,
+                "runtime_seconds": level_time,
+                "best": {
+                    "loss": best_loss,
+                    "center_x": best_center_x,
+                    "center_y": best_center_y,
+                    "angle_deg": best_angle,
+                },
+                "level_best": level_best,
+            }
+        )
+
+        if verbose:
+            print(
+                f"Level {level_index}: "
+                f"evals={level_eval_index}, "
+                f"time={level_time:.2f}s, "
+                f"best_loss={best_loss:.8g}, "
+                f"center=({best_center_x:.4f}, {best_center_y:.4f}), "
+                f"angle={best_angle:.4f}"
+            )
+
+    total_time = time.perf_counter() - t0
+
+    return {
+        "center_x": float(best_center_x),
+        "center_y": float(best_center_y),
+        "angle_deg": float(best_angle),
+        "loss": float(best_loss),
+        "history": history,
+        "all_evaluations": all_eval_rows,
+        "total_evaluations": total_evals,
+        "total_runtime_seconds": total_time,
+    }

--- a/musclex/headless/EquatorWindowh.py
+++ b/musclex/headless/EquatorWindowh.py
@@ -318,6 +318,7 @@ class EquatorWindowh:
                 "sdd",
                 "pixel_size",
                 "lambda",
+                "beam_energy",
             )
             if k in settings
         ]

--- a/musclex/tests/test_calibration_refinement_adapter.py
+++ b/musclex/tests/test_calibration_refinement_adapter.py
@@ -1,0 +1,161 @@
+import sys
+import importlib
+from types import SimpleNamespace
+
+import numpy as np
+
+from musclex.algorithms.calibration_refinement import adapter
+
+
+def test_center_method_selection_cascades_to_required_previous_stages():
+    assert adapter._ordered_center_methods(["gradient"]) == [
+        "registration",
+        "gradient",
+    ]
+    assert adapter._ordered_center_methods(["search"]) == [
+        "registration",
+        "gradient",
+        "search",
+    ]
+
+
+def test_package_refine_center_name_is_not_callable_api():
+    import musclex.algorithms.calibration_refinement as package
+
+    if hasattr(package, "refine_center"):
+        delattr(package, "refine_center")
+    assert not hasattr(package, "refine_center")
+    imported = importlib.import_module(
+        "musclex.algorithms.calibration_refinement.refine_center"
+    )
+    assert package.refine_center is imported
+    assert not callable(package.refine_center)
+    assert callable(adapter.refine_center)
+
+
+def test_center_refinement_runs_methods_in_pipeline_order(monkeypatch):
+    calls = []
+
+    def make_grid(width, height, radius_x=None, radius_y=None):
+        return np.zeros((1, 1)), np.zeros((1, 1))
+
+    reg = SimpleNamespace(
+        make_canonical_grid=make_grid,
+        run_ecc_refinement=lambda **kwargs: calls.append("registration")
+        or {
+            "best_center": (11.0, 12.0),
+            "best_angle_deg": 3.0,
+            "best_loss": 9.0,
+        },
+    )
+    grad = SimpleNamespace(
+        make_canonical_grid=make_grid,
+        optimize_symmetry_gradient=lambda **kwargs: calls.append("gradient")
+        or {
+            "center_x": 12.0,
+            "center_y": 13.0,
+            "angle_deg": 4.0,
+            "loss": 8.0,
+        },
+    )
+    search = SimpleNamespace(
+        make_canonical_grid=make_grid,
+        parse_levels=lambda levels: [{"level": levels}],
+        coarse_to_fine_search=lambda **kwargs: calls.append("search")
+        or {
+            "center_x": 13.0,
+            "center_y": 14.0,
+            "angle_deg": 5.0,
+            "loss": 7.0,
+        },
+    )
+
+    monkeypatch.setitem(
+        sys.modules,
+        "musclex.algorithms.calibration_refinement.refine_center.registration_refinement",
+        reg,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "musclex.algorithms.calibration_refinement.refine_center.gradient_refinement",
+        grad,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "musclex.algorithms.calibration_refinement.refine_center.search_refinement",
+        search,
+    )
+
+    result = adapter.refine_center(
+        np.ones((8, 8)),
+        None,
+        (10.0, 10.0),
+        2.0,
+        ["search", "registration", "gradient"],
+    )
+
+    assert calls == ["registration", "gradient", "search"]
+    assert result["center"] == (13.0, 14.0)
+    assert result["rotation"] == 5.0
+
+
+def test_rotation_refinement_keeps_center_fixed(monkeypatch):
+    captured = {}
+
+    def coarse_to_fine_search(**kwargs):
+        captured.update(kwargs)
+        return {"center_x": 99.0, "center_y": 99.0, "angle_deg": 4.5, "loss": 1.0}
+
+    rotation_search = SimpleNamespace(
+        make_canonical_grid=lambda *args, **kwargs: (
+            np.zeros((1, 1)),
+            np.zeros((1, 1)),
+        ),
+        parse_angle_only_levels=lambda levels: [{"level": levels}],
+        coarse_to_fine_search=coarse_to_fine_search,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "musclex.algorithms.calibration_refinement.refine_rotation",
+        rotation_search,
+    )
+
+    result = adapter.refine_rotation(np.ones((8, 8)), None, (3.0, 4.0), 2.0)
+
+    assert captured["init_center"] == (3.0, 4.0)
+    assert result["center"] == (3.0, 4.0)
+    assert result["rotation"] == 4.5
+
+
+def test_mask_is_converted_to_excluded_pixel_mask(monkeypatch):
+    captured = {}
+
+    def coarse_to_fine_search(**kwargs):
+        captured.update(kwargs)
+        return {"center_x": 3.0, "center_y": 4.0, "angle_deg": 2.0, "loss": 1.0}
+
+    search = SimpleNamespace(
+        make_canonical_grid=lambda *args, **kwargs: (
+            np.zeros((1, 1)),
+            np.zeros((1, 1)),
+        ),
+        parse_levels=lambda levels: [{"level": levels}],
+        coarse_to_fine_search=coarse_to_fine_search,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "musclex.algorithms.calibration_refinement.refine_center.search_refinement",
+        search,
+    )
+
+    adapter.refine_center(
+        np.ones((4, 4)),
+        np.array([[0, 1, 0, 0]] * 4),
+        (2.0, 2.0),
+        0.0,
+        ["search"],
+    )
+
+    assert captured["mask"].dtype == np.uint8
+    assert captured["mask"][0, 0] == 0
+    assert captured["mask"][0, 1] == 1

--- a/musclex/tests/test_calibration_settings_dialog.py
+++ b/musclex/tests/test_calibration_settings_dialog.py
@@ -1,0 +1,152 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+pytest.importorskip("PySide6")
+pytest.importorskip("pyFAI")
+
+from PySide6.QtWidgets import QApplication
+
+from musclex.CalibrationSettings.CalibrationSettings import (
+    CUSTOM_MAR_165_2X2,
+    CalibrationSettings,
+    _find_mar_165_base_detector_name,
+    _halved_shape,
+)
+
+
+class _FakeSettingsManager:
+    def __init__(self):
+        self.saved_cache = None
+
+    def save_calibration_cache(self, cache):
+        self.saved_cache = cache
+
+    def load_calibration_cache_file(self, *args, **kwargs):
+        return None
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _dialog(tmp_path, settings):
+    return CalibrationSettings(
+        str(tmp_path),
+        initial_settings={
+            "path": str(tmp_path / "calibration.tif"),
+            "settings": settings,
+        },
+        settings_manager=_FakeSettingsManager(),
+    )
+
+
+def test_detector_choices_are_sorted_and_include_mar_165_2x2():
+    choices = CalibrationSettings._detector_choices()
+
+    assert choices == sorted(choices, key=str.casefold)
+    assert CUSTOM_MAR_165_2X2 in choices
+
+
+def test_custom_mar_165_2x2_metadata_doubles_base_pixel_size_and_halves_shape():
+    base_name, pixel_size, shape = CalibrationSettings._custom_mar_165_2x2_metadata()
+
+    assert pixel_size > 0
+    assert base_name == _find_mar_165_base_detector_name()
+
+    base_pixel_size = None
+    if base_name:
+        base_pixel_size = CalibrationSettings._detector_pixel_size_mm(None, base_name)
+    if base_pixel_size:
+        assert pixel_size == pytest.approx(base_pixel_size * 2.0)
+
+    if shape:
+        from pyFAI.detectors import Detector
+
+        base_shape = None
+        if base_name:
+            base_shape = getattr(Detector.registry.get(base_name), "MAX_SHAPE", None)
+        if base_shape:
+            assert shape == _halved_shape(base_shape)
+
+
+def test_manual_pixel_size_clears_manual_detector_selection(qapp, tmp_path):
+    dialog = _dialog(
+        tmp_path,
+        {
+            "type": "cont",
+            "lambda": 0.1,
+            "beam_energy": 12.39841984,
+            "sdd": 2000.0,
+            "pixel_size": 0.079,
+            "detector": CUSTOM_MAR_165_2X2,
+        },
+    )
+
+    dialog.manDetector.setChecked(True)
+    dialog.detectorChoice.setCurrentText(CUSTOM_MAR_165_2X2)
+    dialog._apply_manual_detector_metadata()
+    assert dialog.detector_metadata
+
+    dialog.pixsSpnBx.setValue(0.2)
+    dialog.settingChanged("pixS", dialog.pixsSpnBx)
+
+    assert not dialog.manDetector.isChecked()
+    assert not dialog.detectorChoice.isEnabled()
+    assert dialog.detector_metadata == {}
+
+    assert dialog.saveSettings()
+    saved = dialog._settings_manager.saved_cache["settings"]
+    assert saved["pixel_size"] == pytest.approx(0.2)
+    assert "detector" not in saved
+    assert "detector_metadata" not in saved
+
+
+def test_calibration_image_syncs_scale_and_inferred_sdd(qapp, tmp_path):
+    dialog = _dialog(
+        tmp_path,
+        {
+            "type": "img",
+            "silverB": 5.0,
+            "radius": 100.0,
+            "scale": 500.0,
+            "center": [10.0, 20.0],
+        },
+    )
+    dialog.lambdaSpnBx.setValue(0.1)
+    dialog.pixsSpnBx.setValue(0.2)
+    dialog.silverBehenate.setValue(5.0)
+
+    dialog._sync_parameters_from_calibration_image()
+
+    assert dialog.calSettings["scale"] == pytest.approx(500.0)
+    assert dialog.sddSpnBx.value() == pytest.approx(1000.0)
+    assert "500" in dialog.scaleComputedLabel.text()
+    assert "1000" in dialog.sddComputedLabel.text()
+
+
+def test_invalid_pixel_size_leaves_sdd_and_computed_sdd_unavailable(qapp, tmp_path):
+    dialog = _dialog(
+        tmp_path,
+        {
+            "type": "img",
+            "silverB": 5.0,
+            "radius": 100.0,
+            "scale": 500.0,
+            "center": [10.0, 20.0],
+        },
+    )
+    dialog.lambdaSpnBx.setValue(0.1)
+    dialog.pixsSpnBx.setValue(0.0)
+    dialog.sddSpnBx.setValue(1234.0)
+
+    dialog._sync_parameters_from_calibration_image()
+
+    assert dialog.sddSpnBx.value() == pytest.approx(1234.0)
+    assert "unavailable" in dialog.sddComputedLabel.text()

--- a/musclex/ui/EquatorWindow.py
+++ b/musclex/ui/EquatorWindow.py
@@ -1862,6 +1862,7 @@ class EquatorWindow(QMainWindow):
             "sdd",
             "pixel_size",
             "lambda",
+            "beam_energy",
         ):
             settings.pop(k, None)
 

--- a/musclex/ui/ProjectionTracesGUI.py
+++ b/musclex/ui/ProjectionTracesGUI.py
@@ -3268,6 +3268,8 @@ class ProjectionTracesGUI(BaseGUI):
             # Instrument-based calibration parameters
             if "lambda" in calSettings:
                 cache["lambda"] = calSettings["lambda"]
+            if "beam_energy" in calSettings:
+                cache["beam_energy"] = calSettings["beam_energy"]
             if "sdd" in calSettings:
                 cache["sdd"] = calSettings["sdd"]
             if "pixel_size" in calSettings:

--- a/musclex/ui/QuadrantFoldingGUI.py
+++ b/musclex/ui/QuadrantFoldingGUI.py
@@ -3972,13 +3972,11 @@ class QuadrantFoldingGUI(BaseGUI):
         Clean up info dict when changing images
         """
 
-        # Clean up detector info if not manually set
-        if (
-            not (
-                self.calSettingsDialog
-                and self.calSettingsDialog.manDetector.isChecked()
-            )
-        ) and (prevInfo is not None):
+        # Clean up stale detector info unless current calibration supplies one.
+        has_calibration_detector = bool(
+            self.calSettings is not None and self.calSettings.get("detector")
+        )
+        if not has_calibration_detector and (prevInfo is not None):
             if "detector" in currentInfo:
                 del currentInfo["detector"]
 

--- a/musclex/ui/QuadrantFoldingGUI.py
+++ b/musclex/ui/QuadrantFoldingGUI.py
@@ -772,8 +772,10 @@ class QuadrantFoldingGUI(BaseGUI):
                 self.workspace._center_widget.setCentByChords,
                 self.workspace._center_widget.setCentByPerp,
                 self.workspace._center_widget.setCentBtn,
+                self.workspace._center_widget.refineCenterBtn,
                 self.workspace._rotation_widget.setRotationButton,
                 self.workspace._rotation_widget.setAngleBtn,
+                self.workspace._rotation_widget.refineRotationBtn,
             ]
         )
 

--- a/musclex/ui/widgets/center_settings_widget.py
+++ b/musclex/ui/widgets/center_settings_widget.py
@@ -14,6 +14,7 @@ from PySide6.QtWidgets import (
     QRadioButton,
     QDialogButtonBox,
     QMessageBox,
+    QCheckBox,
 )
 from PySide6.QtCore import Signal
 from .collapsible_groupbox import CollapsibleGroupBox
@@ -124,6 +125,64 @@ class RestoreAutoCenterDialog(QDialog):
             return "all"
 
 
+class RefineCenterDialog(QDialog):
+    """Dialog for selecting center refinement pipeline stages."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Refine Center")
+
+        layout = QVBoxLayout()
+        layout.addWidget(QLabel("Select refinement stages:"))
+
+        self.registrationChkBx = QCheckBox("Registration")
+        self.gradientChkBx = QCheckBox("Gradient")
+        self.searchChkBx = QCheckBox("Local Search")
+
+        self.registrationChkBx.setToolTip("Run ECC registration refinement")
+        self.gradientChkBx.setToolTip("Run gradient refinement after registration")
+        self.searchChkBx.setToolTip(
+            "Run local search after registration and gradient refinement"
+        )
+
+        layout.addWidget(self.registrationChkBx)
+        layout.addWidget(self.gradientChkBx)
+        layout.addWidget(self.searchChkBx)
+
+        self.buttonBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        self.buttonBox.accepted.connect(self.accept)
+        self.buttonBox.rejected.connect(self.reject)
+        layout.addWidget(self.buttonBox)
+
+        self.setLayout(layout)
+        self.registrationChkBx.stateChanged.connect(self._sync_pipeline)
+        self.gradientChkBx.stateChanged.connect(self._sync_pipeline)
+        self.searchChkBx.stateChanged.connect(self._sync_pipeline)
+        self._sync_pipeline()
+
+    def _sync_pipeline(self):
+        if self.searchChkBx.isChecked():
+            self.gradientChkBx.setChecked(True)
+        if self.gradientChkBx.isChecked():
+            self.registrationChkBx.setChecked(True)
+        ok_button = self.buttonBox.button(QDialogButtonBox.Ok)
+        ok_button.setEnabled(
+            self.registrationChkBx.isChecked()
+            or self.gradientChkBx.isChecked()
+            or self.searchChkBx.isChecked()
+        )
+
+    def getMethods(self):
+        methods = []
+        if self.registrationChkBx.isChecked():
+            methods.append("registration")
+        if self.gradientChkBx.isChecked():
+            methods.append("gradient")
+        if self.searchChkBx.isChecked():
+            methods.append("search")
+        return methods
+
+
 class CenterSettingsWidget(CollapsibleGroupBox):
     """
     Widget for center point settings.
@@ -142,6 +201,7 @@ class CenterSettingsWidget(CollapsibleGroupBox):
     # Signals for complex interactions (that require dialog selection)
     applyCenterRequested = Signal(str)  # scope
     restoreAutoCenterRequested = Signal(str)  # scope
+    refineCenterRequested = Signal(list)  # selected methods
 
     def __init__(self, parent=None):
         super().__init__("Set Center", start_expanded=True, parent=parent)
@@ -178,6 +238,11 @@ class CenterSettingsWidget(CollapsibleGroupBox):
         self.setCentBtn.setCheckable(False)
         self.setCentBtn.setToolTip(
             "Click a single point on the image to use as the center"
+        )
+
+        self.refineCenterBtn = QPushButton("Refine Center")
+        self.refineCenterBtn.setToolTip(
+            "Refine the current center once and save it as a manual center"
         )
 
         # Labels for displaying center info
@@ -219,6 +284,9 @@ class CenterSettingsWidget(CollapsibleGroupBox):
         layout.addWidget(self.setCentByPerp, row, 2, 1, 2)
         row += 1
 
+        layout.addWidget(self.refineCenterBtn, row, 0, 1, 4)
+        row += 1
+
         layout.addWidget(self.centerLabel, row, 0, 1, 4)
         row += 1
 
@@ -234,6 +302,7 @@ class CenterSettingsWidget(CollapsibleGroupBox):
         """Connect buttons that need internal dialog handling"""
         self.applyCenterBtn.clicked.connect(self._on_apply_center_clicked)
         self.restoreAutoCenterBtn.clicked.connect(self._on_restore_center_clicked)
+        self.refineCenterBtn.clicked.connect(self._on_refine_center_clicked)
 
     def _on_apply_center_clicked(self):
         """Handle Apply Center button - show dialog and emit signal"""
@@ -248,6 +317,12 @@ class CenterSettingsWidget(CollapsibleGroupBox):
         if dialog.exec() == QDialog.Accepted:
             scope = dialog.getSelection()
             self.restoreAutoCenterRequested.emit(scope)
+
+    def _on_refine_center_clicked(self):
+        """Handle Refine Center button - show dialog and emit signal"""
+        dialog = RefineCenterDialog(self)
+        if dialog.exec() == QDialog.Accepted:
+            self.refineCenterRequested.emit(dialog.getMethods())
 
     # Public methods for updating display
 

--- a/musclex/ui/widgets/processing_workspace.py
+++ b/musclex/ui/widgets/processing_workspace.py
@@ -1864,6 +1864,15 @@ class ProcessingWorkspace(QWidget):
             cal_settings = cal_dialog.getValues()
 
             if cal_settings is not None:
+                if image_data.update_detector(cal_settings.get("detector")):
+                    self.settings_manager.set_auto_cache(
+                        image_data.img_name,
+                        image_data._computed_center,
+                        None,
+                        detector=image_data.detector,
+                    )
+                    self.settings_manager.save_auto_cache()
+
                 if "center" in cal_settings:
                     # Update center using workspace method
                     self.set_center_from_source(

--- a/musclex/ui/widgets/processing_workspace.py
+++ b/musclex/ui/widgets/processing_workspace.py
@@ -1933,7 +1933,7 @@ class ProcessingWorkspace(QWidget):
         Returns the 'settings' dict from calibration.info, which contains:
         - type: "img" or "cont"
         - For "img" type: silverB, radius
-        - For "cont" type: lambda, sdd, pixel_size, scale
+        - For "cont" type: lambda, beam_energy, sdd, pixel_size, scale
         - center: [x, y] (optional)
         - detector: detector name (optional)
 

--- a/musclex/ui/widgets/processing_workspace.py
+++ b/musclex/ui/widgets/processing_workspace.py
@@ -27,10 +27,19 @@ authorization from Illinois Institute of Technology.
 """
 
 import json
+import traceback
 from pathlib import Path
 from typing import Optional, Tuple
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QDialog
-from PySide6.QtCore import Signal
+import numpy as np
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QDialog,
+    QMessageBox,
+    QProgressDialog,
+)
+from PySide6.QtCore import Signal, QObject, QRunnable, QThreadPool, Qt
 
 from ...utils.image_data import ImageData
 from ...utils.settings_manager import SettingsManager
@@ -40,6 +49,55 @@ from .collapsible_right_panel import CollapsibleRightPanel
 from .center_settings_widget import CenterSettingsWidget
 from .rotation_settings_widget import RotationSettingsWidget
 from .blank_mask_settings_widget import BlankMaskSettingsWidget
+
+
+class _RefinementWorkerSignals(QObject):
+    result = Signal(object)
+    error = Signal(object)
+    finished = Signal()
+
+
+class _RefinementWorker(QRunnable):
+    def __init__(self, kind, image, mask, center, rotation, methods=None):
+        super().__init__()
+        self.kind = kind
+        self.image = image
+        self.mask = mask
+        self.center = center
+        self.rotation = rotation
+        self.methods = methods or []
+        self.signals = _RefinementWorkerSignals()
+
+    def run(self):
+        try:
+            from ...algorithms.calibration_refinement.adapter import (
+                refine_center,
+                refine_rotation,
+            )
+
+            if self.kind == "center":
+                result = refine_center(
+                    self.image,
+                    self.mask,
+                    self.center,
+                    self.rotation,
+                    self.methods,
+                )
+            else:
+                result = refine_rotation(
+                    self.image,
+                    self.mask,
+                    self.center,
+                    self.rotation,
+                )
+        except Exception as exc:
+            self.signals.error.emit(
+                {"error": str(exc), "traceback": traceback.format_exc()}
+            )
+        else:
+            self.signals.result.emit(result)
+        finally:
+            self.signals.finished.emit()
 
 
 class ProcessingWorkspace(QWidget):
@@ -148,6 +206,12 @@ class ProcessingWorkspace(QWidget):
         self._mode_rotation = None  # Cached mode rotation value
         self._batch_all_center = None
         self._batch_all_rotation = None
+        self._refinement_progress = None
+        self._refinement_worker = None
+        self._refinement_initial_center = None
+        self._refinement_initial_rotation = None
+        self._refinement_thread_pool = QThreadPool()
+        self._refinement_thread_pool.setMaxThreadCount(1)
 
         # Centralized settings I/O
         self.settings_manager = SettingsManager(settings_dir)
@@ -280,11 +344,17 @@ class ProcessingWorkspace(QWidget):
         self._center_widget.calibrationButton.clicked.connect(
             self._on_calibration_button_clicked
         )
+        self._center_widget.refineCenterRequested.connect(
+            self._on_refine_center_requested
+        )
         self._rotation_widget.setRotationButton.clicked.connect(
             lambda checked: self._on_rotation_button_clicked(checked)
         )
         self._rotation_widget.setAngleBtn.clicked.connect(
             self._on_set_angle_manually_clicked
+        )
+        self._rotation_widget.refineRotationRequested.connect(
+            self._on_refine_rotation_requested
         )
 
         # Tool completed -> Handle result
@@ -495,6 +565,147 @@ class ProcessingWorkspace(QWidget):
             print(
                 f"Rotation manually set with increment {angle_increment:.2f}° from SetAngleDialog"
             )
+
+    def _get_refinement_inputs(self):
+        """Return image/mask/geometry in original image coordinates."""
+        if not self._current_image_data:
+            raise ValueError("No image loaded.")
+
+        image_data = self._current_image_data
+        image = image_data.get_working_image()
+        mask = np.zeros(image.shape, dtype=np.uint8)
+
+        if image_data.apply_mask:
+            image_data._load_blank_and_mask()
+            masks = []
+            if image_data._mask is not None:
+                masks.append(image_data._mask == 0)
+            if image_data._mask_only is not None:
+                masks.append(image_data._mask_only == 0)
+            if masks:
+                excluded = np.logical_or.reduce(masks)
+                mask[excluded] = 1
+
+        return image, mask, image_data.center, image_data.rotation
+
+    def _show_refinement_progress(self, title, message):
+        progress = QProgressDialog(message, None, 0, 0, self.window())
+        progress.setWindowTitle(title)
+        progress.setWindowModality(Qt.WindowModal)
+        progress.setCancelButton(None)
+        progress.setMinimumDuration(0)
+        progress.setAutoClose(False)
+        progress.setAutoReset(False)
+        progress.show()
+        self._refinement_progress = progress
+
+    def _close_refinement_progress(self):
+        if self._refinement_progress is not None:
+            self._refinement_progress.close()
+            self._refinement_progress = None
+
+    def _start_refinement(self, kind, methods=None):
+        if self._refinement_worker is not None:
+            QMessageBox.information(
+                self.window(),
+                "Refinement Running",
+                "A calibration refinement is already running.",
+            )
+            return
+
+        try:
+            image, mask, center, rotation = self._get_refinement_inputs()
+        except Exception as exc:
+            QMessageBox.warning(self.window(), "Refinement Unavailable", str(exc))
+            return
+
+        if kind == "center":
+            title = "Refine Center"
+            message = "Refining center..."
+        else:
+            title = "Refine Rotation"
+            message = "Refining rotation..."
+
+        self._show_refinement_progress(title, message)
+        self._refinement_initial_center = tuple(center) if center is not None else None
+        self._refinement_initial_rotation = rotation
+        worker = _RefinementWorker(kind, image, mask, center, rotation, methods)
+        self._refinement_worker = worker
+        if kind == "center":
+            worker.signals.result.connect(self._on_refine_center_result)
+        else:
+            worker.signals.result.connect(self._on_refine_rotation_result)
+        worker.signals.error.connect(self._on_refinement_error)
+        worker.signals.finished.connect(self._on_refinement_finished)
+        self._refinement_thread_pool.start(worker)
+
+    def _on_refine_center_requested(self, methods):
+        self._start_refinement("center", methods=methods)
+
+    def _on_refine_rotation_requested(self):
+        self._start_refinement("rotation")
+
+    def _on_refine_center_result(self, result):
+        self._close_refinement_progress()
+        old_center = self._refinement_initial_center
+        center = tuple(result["center"])
+        self.set_center_from_source(
+            self._current_filename,
+            center,
+            "calibration_refinement_center",
+        )
+        self.needsReprocess.emit()
+        QMessageBox.information(
+            self.window(),
+            "Center Refined",
+            (
+                f"Center refined from x={old_center[0]:.2f}, y={old_center[1]:.2f} px "
+                f"to x={center[0]:.2f}, y={center[1]:.2f} px."
+                if old_center is not None
+                else f"Center refined to x={center[0]:.2f}, y={center[1]:.2f} px."
+            ),
+        )
+
+    def _on_refine_rotation_result(self, result):
+        self._close_refinement_progress()
+        old_rotation = self._refinement_initial_rotation
+        rotation = float(result["rotation"])
+        self.set_absolute_rotation_from_source(
+            self._current_filename,
+            rotation,
+            "calibration_refinement_rotation",
+        )
+        self.needsReprocess.emit()
+        QMessageBox.information(
+            self.window(),
+            "Rotation Refined",
+            (
+                f"Rotation refined from {float(old_rotation) % 360:.2f} ° "
+                f"to {rotation % 360:.2f} °."
+                if old_rotation is not None
+                else f"Rotation refined to {rotation % 360:.2f} °."
+            ),
+        )
+
+    def _on_refinement_error(self, payload):
+        self._close_refinement_progress()
+        error = (
+            payload.get("error", "Unknown error")
+            if isinstance(payload, dict)
+            else str(payload)
+        )
+        details = payload.get("traceback", "") if isinstance(payload, dict) else ""
+        QMessageBox.critical(
+            self.window(),
+            "Refinement Failed",
+            f"{error}\n\n{details}",
+        )
+
+    def _on_refinement_finished(self):
+        self._close_refinement_progress()
+        self._refinement_worker = None
+        self._refinement_initial_center = None
+        self._refinement_initial_rotation = None
 
     # ==================== Tool Completion Handlers ====================
 
@@ -836,6 +1047,25 @@ class ProcessingWorkspace(QWidget):
             else:
                 new_rotation = self.settings_manager.get_rotation(filename)
                 self._current_image_data.update_manual_rotation(new_rotation)
+            self.update_display(self._current_image_data)
+
+    def set_absolute_rotation_from_source(
+        self, filename: str, rotation: Optional[float], source: str
+    ):
+        """
+        Public method for setting an absolute manual rotation value.
+
+        Refinement returns the final rotation angle, unlike SetAngleDialog which
+        returns an increment relative to the current displayed image.
+        """
+        if rotation is None:
+            self.settings_manager.clear_rotation(filename)
+        else:
+            self.settings_manager.set_rotation(filename, rotation, source)
+        self.save_settings()
+
+        if self._current_image_data and self._current_filename == filename:
+            self._current_image_data.update_manual_rotation(rotation)
             self.update_display(self._current_image_data)
 
     def get_manual_settings(

--- a/musclex/ui/widgets/rotation_settings_widget.py
+++ b/musclex/ui/widgets/rotation_settings_widget.py
@@ -211,6 +211,7 @@ class RotationSettingsWidget(CollapsibleGroupBox):
     autoOrientationRequested = Signal(int, bool)  # orientation_model, mode_enabled
     applyRotationRequested = Signal(str)  # scope
     restoreAutoRotationRequested = Signal(str)  # scope
+    refineRotationRequested = Signal()
 
     def __init__(
         self, parent=None, orientation_model=None, mode_orientation_enabled=False
@@ -237,6 +238,11 @@ class RotationSettingsWidget(CollapsibleGroupBox):
         self.setAngleBtn = QPushButton("Set Angle Manually")
         self.setAngleBtn.setCheckable(False)
         self.setAngleBtn.setToolTip("Type the rotation angle in degrees in a dialog")
+
+        self.refineRotationBtn = QPushButton("Refine Rotation")
+        self.refineRotationBtn.setToolTip(
+            "Refine the current rotation once with the current center fixed"
+        )
 
         # Labels for displaying rotation info
         self.rotationLabel = QLabel()
@@ -273,6 +279,9 @@ class RotationSettingsWidget(CollapsibleGroupBox):
         layout.addWidget(self.setAngleBtn, row, 2, 1, 2)
         row += 1
 
+        layout.addWidget(self.refineRotationBtn, row, 0, 1, 4)
+        row += 1
+
         layout.addWidget(self.rotationLabel, row, 0, 1, 4)
         row += 1
 
@@ -287,6 +296,7 @@ class RotationSettingsWidget(CollapsibleGroupBox):
     def _connect_internal(self):
         """Connect buttons that need internal dialog handling"""
         self.setAutoOrientationBtn.clicked.connect(self._on_auto_orientation_clicked)
+        self.refineRotationBtn.clicked.connect(self.refineRotationRequested.emit)
         self.applyRotationBtn.clicked.connect(self._on_apply_rotation_clicked)
         self.restoreAutoRotationBtn.clicked.connect(self._on_restore_rotation_clicked)
 

--- a/musclex/utils/eq_settings_bindings.py
+++ b/musclex/utils/eq_settings_bindings.py
@@ -139,7 +139,7 @@ EQ_SPECIAL_KEYS = frozenset(
 # subsystem and the EQ load path intentionally ignores them.
 #
 #   - Calibration-derived fields (lambda_sdd, detector, calib_center,
-#     silverB, radius, type, sdd, pixel_size, lambda):
+#     silverB, radius, type, sdd, pixel_size, lambda, beam_energy):
 #     single-sourced from <dataset>/settings/calibration.info via
 #     SettingsManager. EquatorWindow.saveSettings() strips these on
 #     export and EquatorWindowh.getSettings() strips them on import,
@@ -158,6 +158,7 @@ EQ_SKIP_KEYS = frozenset(
         "sdd",
         "pixel_size",
         "lambda",
+        "beam_energy",
         "blank_mask",
     }
 )

--- a/musclex/utils/image_data.py
+++ b/musclex/utils/image_data.py
@@ -248,6 +248,14 @@ class ImageData:
         # Pass settings_manager if available on the panel
         sm = getattr(settings_panel, "settings_manager", None)
 
+        detector = None
+        try:
+            cal_settings = settings_panel.calibration_settings
+            if cal_settings is not None:
+                detector = cal_settings.get("detector")
+        except Exception:
+            detector = None
+
         return cls(
             img=img,
             img_path=img_path,
@@ -255,6 +263,7 @@ class ImageData:
             center=manual_center,
             rotation=manual_rotation,
             orientation_model=orientation_model,
+            detector=detector,
             apply_blank=blank_mask_config["apply_blank"],
             apply_mask=blank_mask_config["apply_mask"],
             blank_weight=blank_mask_config["blank_weight"],
@@ -390,6 +399,21 @@ class ImageData:
         self._manual_rotation = rotation
         print(f"Manual rotation updated: {self._manual_rotation}")
 
+    def update_detector(self, detector: Optional[str]) -> bool:
+        """
+        Update detector at runtime and invalidate auto-rotation if it changed.
+
+        :param detector: PyFAI detector name or None
+        :return: True if detector changed
+        """
+        if self.detector == detector:
+            return False
+        previous = self.detector
+        self.detector = detector
+        self._computed_rotation = None
+        print(f"Detector updated: {previous} -> {self.detector}")
+        return True
+
     # ==================== Cache Management ====================
 
     def _load_auto_cache(self):
@@ -398,10 +422,21 @@ class ImageData:
             return
         c = self._settings_manager.get_auto_center(self.img_name)
         r = self._settings_manager.get_auto_rotation(self.img_name)
+        cached_detector = None
+        if hasattr(self._settings_manager, "get_auto_cache_detector"):
+            cached_detector = self._settings_manager.get_auto_cache_detector(
+                self.img_name
+            )
         if c is not None:
             self._computed_center = c
-        if r is not None:
+        detector_matches = cached_detector == self.detector
+        if r is not None and detector_matches:
             self._computed_rotation = r
+        elif r is not None and not detector_matches:
+            print(
+                "Ignoring cached auto rotation because detector changed: "
+                f"cached={cached_detector}, current={self.detector}"
+            )
         if c or r is not None:
             print(
                 f"Loaded auto geometry from cache: center={self._computed_center}, rotation={self._computed_rotation}"
@@ -412,7 +447,10 @@ class ImageData:
         if self._settings_manager is None:
             return
         self._settings_manager.set_auto_cache(
-            self.img_name, self._computed_center, self._computed_rotation
+            self.img_name,
+            self._computed_center,
+            self._computed_rotation,
+            detector=self.detector,
         )
         self._settings_manager.save_auto_cache()
 

--- a/musclex/utils/qf_settings_bindings.py
+++ b/musclex/utils/qf_settings_bindings.py
@@ -148,6 +148,7 @@ QF_SKIP_KEYS = frozenset(
         "silverB",
         "radius",
         "type",
+        "beam_energy",
     }
 )
 

--- a/musclex/utils/settings_manager.py
+++ b/musclex/utils/settings_manager.py
@@ -236,10 +236,17 @@ class SettingsManager:
             return data["rotation"]
         return None
 
-    def set_auto_cache(self, filename: str, center, rotation):
+    def get_auto_cache_detector(self, filename: str) -> Optional[str]:
+        data = self._auto_cache.get(filename)
+        if data:
+            return data.get("detector")
+        return None
+
+    def set_auto_cache(self, filename: str, center, rotation, detector=None):
         self._auto_cache[filename] = {
             "center": list(center) if center else None,
             "rotation": rotation if rotation is not None else None,
+            "detector": detector if detector is not None else None,
         }
 
     # ===== Global base =====


### PR DESCRIPTION
- Pixel size now starts as Unknown instead of silently defaulting to 0.172.
- Calibration image loading now keeps the FabIO object and probes detector/header metadata.
- Detector matching uses FabIO metadata first, then PyFAI registry shape matching.
- Pixel size is filled from PyFAI detector metadata when available, or from FabIO header pixel-size fields as fallback.
- Parameter calibration now prompts for pixel size if none was detected/entered.
- Saved calibration includes detector metadata and pixel-size source.
- OK stays open if the user cancels the required pixel-size prompt.
- Small guard added so unchecking detector does not crash when calSettings is empty.